### PR TITLE
Decode RLE textures, light dungeons, and add a screenshot path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.kdev4
 build
+CLAUDE.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,8 +256,11 @@ configure_file("${opendf_SOURCE_DIR}/settings.cfg.in"
                "${opendf_BINARY_DIR}/settings.cfg")
 
 add_executable(opendf ${SRCS} ${HDRS})
-set_property(TARGET opendf APPEND PROPERTY INCLUDE_DIRECTORIES
-    "${opendf_SOURCE_DIR}/src/opendf"
+target_include_directories(opendf PRIVATE "${opendf_SOURCE_DIR}/src/opendf")
+# SYSTEM silences warnings from these headers. OSG 3.6 predates the warnings
+# modern Clang emits for it (-Wdeprecated-copy-with-user-provided-copy,
+# -Woverloaded-virtual), and hundreds of them per TU bury our own.
+target_include_directories(opendf SYSTEM PRIVATE
     ${OPENSCENEGRAPH_INCLUDE_DIRS}
     ${SDL2_INCLUDE_DIR}
     ${OPENGL_INCLUDE_DIR}

--- a/README.md
+++ b/README.md
@@ -42,22 +42,10 @@ macOS (Homebrew):
 
     brew install cmake ninja open-scene-graph sdl2-compat qt freetype
 
-Two caveats on macOS. Homebrew has no `mygui` formula, so MyGUI has to be
-built from source and pointed at with `MYGUI_HOME`; opendf supplies its own
-OSG-backed render manager, so the engine alone is enough:
-
-    git clone --depth 1 --branch MyGUI3.4.4 https://github.com/MyGUI/mygui.git
-    cmake -S mygui -B mygui/build -DCMAKE_INSTALL_PREFIX=$HOME/mygui-install \
-        -DMYGUI_DONT_USE_OBSOLETE=ON \
-        -DMYGUI_RENDERSYSTEM=1 -DMYGUI_BUILD_DEMOS=OFF -DMYGUI_BUILD_TOOLS=OFF \
-        -DMYGUI_BUILD_PLUGINS=OFF -DMYGUI_BUILD_DOCS=OFF
-    cmake --build mygui/build --target install
-    export MYGUI_HOME=$HOME/mygui-install
-
-`MYGUI_DONT_USE_OBSOLETE=ON` there is required, not tidiness: 3.4.4 defaults it
-to `FALSE` and installs no `MyGUI_Config.h`, so opendf's `AUTO` detection treats
-it as a pre-3.5 MyGUI and defines the macro. Building the library without it
-would leave the two disagreeing about every widget's layout.
+Two notes on macOS. Homebrew has no `mygui` formula, and none is needed:
+when MyGUI isn't found, the build fetches and builds MyGUI 3.4.4 in-tree
+automatically -- engine only, configured to match what opendf expects. See
+`OPENDF_FETCH_MYGUI` below to control that.
 
 And there is no `sdl2` formula any more: `sdl2-compat` replaces it, providing
 the same `sdl2.pc` and SDL2 headers on top of SDL3.
@@ -87,12 +75,18 @@ This produces the engine (`opendf`) and a BSA archive tool (`bsatool`) in
 
 Useful CMake options (defaults in parentheses):
 
-    -DBUILD_LAUNCHER=AUTO|ON|OFF build the Qt6 launcher (AUTO)
+    -DBUILD_LAUNCHER=AUTO|ON|OFF           build the Qt6 launcher (AUTO)
+    -DOPENDF_FETCH_MYGUI=AUTO|ON|OFF       build MyGUI in-tree (AUTO)
     -DMYGUI_DONT_USE_OBSOLETE=AUTO|ON|OFF  match how MyGUI was built (AUTO)
 
 `BUILD_LAUNCHER=AUTO` builds the launcher if Qt6 6.2+ is installed and skips it
 otherwise, so an engine-only build needs no Qt6. Pass `ON` to require it (the
 build then fails if Qt6 is missing) or `OFF` to never build it.
+
+`OPENDF_FETCH_MYGUI=AUTO` uses a system MyGUI when `find_package` locates one
+and otherwise fetches and builds MyGUI 3.4.4 in-tree, which is what happens on
+macOS. `ON` always builds in-tree without looking for a system one; `OFF`
+requires a system MyGUI and fails if it is absent.
 
 `MYGUI_DONT_USE_OBSOLETE` has to agree with the `MYGUI_DONT_USE_OBSOLETE` the
 MyGUI you link against was built with -- it changes the layout of every widget,

--- a/README.md
+++ b/README.md
@@ -140,9 +140,26 @@ if it cannot find a `data-root`. Then:
 
 Command line options:
 
-    -data <path>    add a data path (may be given more than once)
-    -log <file>     write the log to <file>
-    -devparm        enable debug-level logging
+    -data <path>       add a data path (may be given more than once)
+    -log <file>        write the log to <file>
+    -devparm           enable debug-level logging
+    -set <cvar> <val>  override a config variable for this run only
+
+`-set` wins over the config file and is never written back to it, so it is
+safe for one-off and scripted runs.
+
+### Screenshots
+
+Press **F12**, or type `screenshot [path]` in the console.
+
+For non-interactive use -- checking what the renderer actually produced
+without a window to look at -- `r_shotframe` renders that many frames, writes
+one PNG, and quits:
+
+    ./build/opendf -set r_shotframe 4 -set r_shotfile /tmp/shot
+
+That writes `/tmp/shot_0_0.png` and exits. `r_shotframe = 0` (the default)
+disables it entirely.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -135,12 +135,30 @@ if it cannot find a `data-root`. Then:
 Command line options:
 
     -data <path>       add a data path (may be given more than once)
-    -log <file>        write the log to <file>
+    -log <file>        write the log to <file> instead of the default
     -devparm           enable debug-level logging
     -set <cvar> <val>  override a config variable for this run only
 
 `-set` wins over the config file and is never written back to it, so it is
 safe for one-off and scripted runs.
+
+The log goes next to the config files -- `$XDG_CONFIG_HOME/opendf/opendf.log`
+(`%AppData%\opendf\opendf.log` on Windows), falling back to
+`~/.config/opendf/` -- rather than into whatever directory you started the
+engine from. `-log` overrides it and is taken exactly as given, so a relative
+path there is still relative to the working directory.
+
+### Lighting
+
+Dungeon lighting follows Daggerfall Unity's values; `docs/ROADMAP.md` records
+which numbers come from where. Three cvars tune it, as percentages:
+
+    r_ambientscale     100   ambient light
+    r_torchscale       100   the player's torch
+    r_lightintensity    80   the lights placed in the dungeon
+
+Change them from the console and type `relight` to apply without reloading, or
+pass them with `-set` for a single run.
 
 ### Screenshots
 

--- a/data/shaders/combiner.frag
+++ b/data/shaders/combiner.frag
@@ -13,5 +13,10 @@ void main()
     vec3 diffuse = texture2DRect(DiffuseTex, TexCoord0.xy).rgb;
     vec3 specular = texture2DRect(SpecularTex, TexCoord0.xy).rgb;
 
-    gl_FragColor = vec4(color*diffuse + specular, 1.0);
+    // Lighting was done in linear space (see the albedo decode in
+    // object/sprite/terrain.frag); encode back to sRGB for display. Without
+    // this every lit surface reads far darker than it should, and a physically
+    // shaped falloff looks broken while a flat one looks "right" by accident.
+    vec3 lit = color*diffuse + specular;
+    gl_FragColor = vec4(pow(max(lit, vec3(0.0)), vec3(1.0/2.2)), 1.0);
 }

--- a/data/shaders/object.frag
+++ b/data/shaders/object.frag
@@ -22,6 +22,13 @@ void main()
                      normalize(b_viewspace),
                      normalize(n_viewspace));
 
+    // Daggerfall's palette colours are authored for a gamma-2.2 display, so
+    // they are sRGB-ish, not linear. Lighting has to happen in linear space or
+    // multiplying by a light value darkens midtones badly; combiner.frag
+    // encodes back to sRGB at the end. The G-buffer is RGBA16F, so linear
+    // albedo stores without banding.
+    color.rgb = pow(color.rgb, vec3(2.2));
+
     gl_FragData[0] = color * vec4(Color.rgb, 1.0);
     gl_FragData[1] = vec4(nmat*(nn.xyz - vec3(0.5)) + vec3(0.5), nn.w);
     gl_FragData[2] = vec4(pos_viewspace, gl_FragCoord.z);

--- a/data/shaders/point_light.frag
+++ b/data/shaders/point_light.frag
@@ -22,15 +22,24 @@ void main()
     vec3 toLight = lightPos_viewspace - p_viewspace;
     float dist = length(toLight);
 
-    // Falls to exactly zero at the light's radius (so a light never leaks past
-    // the volume it claims and never pops), but stays much brighter near the
-    // source than a plain linear ramp would.
-    float atten = clamp(1.0 - (dist*dist)/(light_radius*light_radius), 0.0, 1.0);
-    atten *= atten;
+    // Unity's built-in point light falloff, which is what Daggerfall Unity
+    // gets for its dungeon lights: 1/(1 + 25*(d/r)^2). That never quite
+    // reaches zero, so rescale it to hit exactly 0 at the radius the way the
+    // attenuation texture Unity samples does -- a light must not leak past
+    // the volume it claims, and must not pop when it ends.
+    //
+    // The obvious (1 - d^2/r^2)^2 is a much flatter curve: about 5x brighter
+    // at half the radius, which reads as broad soft pools instead of the
+    // tight bright cores classic-style lighting wants.
+    float t2 = (dist*dist) / (light_radius*light_radius);
+    float atten = clamp((1.0/(1.0 + 25.0*t2) - 1.0/26.0) * (26.0/25.0), 0.0, 1.0);
     if(atten <= 0.0)
         discard;
 
-    vec3 lightDir_viewspace = toLight / dist;
+    // dist can be exactly zero -- the torch rides the camera, so a surface can
+    // land on the light -- and atten is 1.0 there, so the discard above does
+    // not catch it. GLSL 1.20 leaves 0.0/0.0 undefined, so clamp the divisor.
+    vec3 lightDir_viewspace = toLight / max(dist, 1e-4);
 
     // Lambertian diffuse color. No ambient term here -- the lighting pass
     // blends GL_ONE/GL_ONE, and ambient is contributed once by dir_light.

--- a/data/shaders/point_light.frag
+++ b/data/shaders/point_light.frag
@@ -1,0 +1,49 @@
+#version 120
+#extension GL_ARB_texture_rectangle : enable
+#extension GL_ARB_draw_buffers : require
+
+varying vec3 lightPos_viewspace;
+
+uniform vec4 diffuse_color;
+uniform vec4 specular_color;
+uniform float light_radius;
+
+uniform sampler2DRect ColorTex;
+uniform sampler2DRect NormalTex;
+uniform sampler2DRect PosTex;
+
+void main()
+{
+    vec4 c_viewspace = texture2DRect(ColorTex,  gl_FragCoord.xy);
+    vec3 n_viewspace = texture2DRect(NormalTex, gl_FragCoord.xy).xyz*2.0 - vec3(1.0);
+    vec3 p_viewspace = texture2DRect(PosTex,    gl_FragCoord.xy).xyz;
+
+    // Direction from point to light (not vice versa!)
+    vec3 toLight = lightPos_viewspace - p_viewspace;
+    float dist = length(toLight);
+
+    // Falls to exactly zero at the light's radius (so a light never leaks past
+    // the volume it claims and never pops), but stays much brighter near the
+    // source than a plain linear ramp would.
+    float atten = clamp(1.0 - (dist*dist)/(light_radius*light_radius), 0.0, 1.0);
+    atten *= atten;
+    if(atten <= 0.0)
+        discard;
+
+    vec3 lightDir_viewspace = toLight / dist;
+
+    // Lambertian diffuse color. No ambient term here -- the lighting pass
+    // blends GL_ONE/GL_ONE, and ambient is contributed once by dir_light.
+    vec3 diff = diffuse_color.rgb * max(0.0, dot(lightDir_viewspace, n_viewspace)) * atten;
+
+    // Direction from point to camera.
+    vec3 viewDir_viewspace = normalize(-p_viewspace);
+
+    // Blinn-Phong specular highlights.
+    vec3 h_viewspace = normalize(lightDir_viewspace + viewDir_viewspace);
+    float amount = max(0.0, dot(h_viewspace, n_viewspace));
+    vec3 spec = specular_color.rgb * pow(amount, 32.0) * c_viewspace.a * atten;
+
+    gl_FragData[0] = vec4(diff, 1.0);
+    gl_FragData[1] = vec4(spec, 1.0);
+}

--- a/data/shaders/point_light.frag
+++ b/data/shaders/point_light.frag
@@ -31,6 +31,13 @@ void main()
     // The obvious (1 - d^2/r^2)^2 is a much flatter curve: about 5x brighter
     // at half the radius, which reads as broad soft pools instead of the
     // tight bright cores classic-style lighting wants.
+    // A radius of zero is legal in the RDB data, and would make t2 either inf
+    // or -- together with dist 0 -- NaN. NaN survives the clamp and the
+    // atten <= 0.0 test, and this pass blends GL_ONE/GL_ONE, so it would
+    // poison the light buffer rather than just dropping one fragment.
+    if(light_radius <= 0.0)
+        discard;
+
     float t2 = (dist*dist) / (light_radius*light_radius);
     float atten = clamp((1.0/(1.0 + 25.0*t2) - 1.0/26.0) * (26.0/25.0), 0.0, 1.0);
     if(atten <= 0.0)

--- a/data/shaders/point_light.vert
+++ b/data/shaders/point_light.vert
@@ -1,0 +1,16 @@
+#version 120
+
+uniform vec3 light_position;
+
+varying vec3 lightPos_viewspace;
+
+void main()
+{
+    // The light pass inherits the main camera's view matrix (it's a
+    // RELATIVE_RF camera), so this puts the world-space light position into
+    // the same view space the G-buffer's position texture is stored in.
+    lightPos_viewspace = (gl_ModelViewMatrix * vec4(light_position, 1.0)).xyz;
+
+    // Vertex position in main camera Screen space.
+    gl_Position = gl_ProjectionMatrix * gl_Vertex;
+}

--- a/data/shaders/sprite.frag
+++ b/data/shaders/sprite.frag
@@ -23,6 +23,13 @@ void main()
                      normalize(b_viewspace),
                      normalize(n_viewspace));
 
+    // Daggerfall's palette colours are authored for a gamma-2.2 display, so
+    // they are sRGB-ish, not linear. Lighting has to happen in linear space or
+    // multiplying by a light value darkens midtones badly; combiner.frag
+    // encodes back to sRGB at the end. The G-buffer is RGBA16F, so linear
+    // albedo stores without banding.
+    color.rgb = pow(color.rgb, vec3(2.2));
+
     gl_FragData[0] = color * vec4(Color.rgb, 1.0);
     gl_FragData[1] = vec4(nmat*(nn.xyz - vec3(0.5)) + vec3(0.5), nn.w);
     gl_FragData[2] = vec4(pos_viewspace, gl_FragCoord.z);

--- a/data/shaders/terrain.frag
+++ b/data/shaders/terrain.frag
@@ -24,6 +24,13 @@ void main()
                      normalize(b_viewspace),
                      normalize(n_viewspace));
 
+    // Daggerfall's palette colours are authored for a gamma-2.2 display, so
+    // they are sRGB-ish, not linear. Lighting has to happen in linear space or
+    // multiplying by a light value darkens midtones badly; combiner.frag
+    // encodes back to sRGB at the end. The G-buffer is RGBA16F, so linear
+    // albedo stores without banding.
+    color.rgb = pow(color.rgb, vec3(2.2));
+
     gl_FragData[0] = color;
     gl_FragData[1] = vec4(nmat*(nn.xyz - vec3(0.5)) + vec3(0.5), nn.w);
     gl_FragData[2] = vec4(pos_viewspace, gl_FragCoord.z);

--- a/data/shaders/terrain.frag
+++ b/data/shaders/terrain.frag
@@ -12,11 +12,12 @@ varying vec3 n_viewspace;
 varying vec3 t_viewspace;
 varying vec3 b_viewspace;
 varying vec4 TexCoords;
-flat varying uint TexIndex;
+// See terrain.vert: a uint varying does not compile on macOS.
+flat varying float TexIndex;
 
 void main()
 {
-    vec3 coord = vec3(TexCoords.xy, float(TexIndex));
+    vec3 coord = vec3(TexCoords.xy, TexIndex);
     vec4 color = vec4(texture2DArray(diffuseTex, coord).rgb, 0.0);
     vec4 nn = vec4(0.5, 0.5, 1.0, 1.0);
 

--- a/data/shaders/terrain.vert
+++ b/data/shaders/terrain.vert
@@ -9,7 +9,12 @@ varying vec3 n_viewspace;
 varying vec3 t_viewspace;
 varying vec3 b_viewspace;
 varying vec4 TexCoords;
-flat varying uint TexIndex;
+// A float rather than a uint: Apple's GLSL 1.20 compiler rejects a uint
+// varying outright ("syntax error"), even though it advertises
+// GL_EXT_gpu_shader4 and accepts usampler2D, texelFetch2D and
+// gl_InstanceIDARB from the same extension. Still flat, so the index is not
+// interpolated; a float carries tile indices exactly either way.
+flat varying float TexIndex;
 
 void main()
 {
@@ -19,7 +24,7 @@ void main()
 
     gl_Position = gl_ModelViewProjectionMatrix * pos;
     TexCoords = gl_MultiTexCoord0;
-    TexIndex = texelFetch2D(tilemapTex, ivec2(x, y), 0).r;
+    TexIndex = float(texelFetch2D(tilemapTex, ivec2(x, y), 0).r);
 
     pos_viewspace = (gl_ModelViewMatrix * pos).xyz;
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -205,6 +205,40 @@ commitments:
 * **Packaging.** Getting a build into people's hands on all three platforms
   without them having to compile it.
 
+## Curated tables carried over from Daggerfall Unity
+
+Some facts about the data simply aren't *in* the data, so Daggerfall Unity
+keeps hand-maintained lookup tables for them. Where we need the same
+behaviour we have to carry the same tables over; there is no deriving them.
+
+Ported so far:
+
+* **Emissive flats** (`MeshManager::loadFlat`, from DFU
+  `TextureReader.emissiveTextures`) -- fires, torches, braziers, glowing
+  creatures: the flats that light themselves rather than waiting to be lit.
+  185 archive/record pairs.
+
+  Worth recording *why* this is a list. Dungeon lights are separate RDB
+  objects, so "a light sits on this flat" looks like it should identify
+  emitters. Measured across all 1295 blocks, the correlation is strong but
+  wrong at the edges: archive 210 record 12 co-locates with a light 80% of
+  the time and is *not* emissive, record 24 never co-locates and *is*, and
+  roughly half the list is creatures and interior props with no RDB light to
+  correlate against at all. The heuristic also can't work where we need it,
+  since `loadFlat` sees a texture id and never a placement.
+
+Not ported, because nothing consumes them yet -- a table with no caller is
+just somewhere for errors to hide:
+
+* **`DungeonTextureTable`** (`{119, 120, 122, 123, 124, 168}`) -- the dungeon
+  wall texture set, needed once per-dungeon texture swapping lands. Closest
+  to being needed.
+* **Window textures** and the spectral/ghost eye special cases, both in
+  DFU's `TextureReader` -- needed when emissive gets subtler than
+  all-or-nothing, since only the glass or the eyes glow.
+* **Per-race NPC archives** (`MobilePersonBillboard`, 381-398 and 451-456) --
+  needed when townspeople exist.
+
 ## Non-goals
 
 * Shipping game assets. OpenDF requires an existing Daggerfall installation.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -217,9 +217,10 @@ that -- multiplying gamma-encoded palette colours by linear light and writing
 the result straight out, which crushes midtones badly. Every DFU constant
 looked wrong here as a result, and the old `(1 - d^2/r^2)^2` falloff only
 looked acceptable because its excessive brightness cancelled the missing
-gamma. `object/sprite/terrain.frag` now decode albedo with `pow(c, 2.2)` into
-the RGBA16F G-buffer and `combiner.frag` encodes the lit result back; with
-that in place DFU's own numbers produce a sensible image.
+gamma. `data/shaders/object.frag`, `data/shaders/sprite.frag` and
+`data/shaders/terrain.frag` now decode albedo with `pow(c, 2.2)` into the
+RGBA16F G-buffer, and `data/shaders/combiner.frag` encodes the lit result
+back; with that in place DFU's own numbers produce a sensible image.
 
 Matching DFU:
 
@@ -231,9 +232,13 @@ Matching DFU:
 * **Light range** `radius * 3` -- `RDBLayout.AddLight`.
 * **Light intensity** 0.8 -- the `m_Intensity` on DFU's dungeon light prefab,
   applied through `r_lightintensity`.
-* **Falloff** `1/(1 + 25*(d/r)^2)`, Unity's built-in point light shape,
-  rescaled to reach exactly zero at the radius so a light neither leaks past
-  its volume nor pops when it ends.
+* **Falloff**, Unity's built-in point light shape. `1/(1 + 25*(d/r)^2)` is
+  `1/26` at `d == r`, not zero, so it is rescaled to
+  `(1/(1 + 25*(d/r)^2) - 1/26) * 26/25` -- exactly 1 at the source and exactly
+  0 at the radius, so a light neither leaks past the volume it claims nor pops
+  when it ends. A radius of zero is rejected before the division; the RDB
+  permits one, and it would otherwise put a NaN into an additively blended
+  light buffer.
 * **Player torch** -- a white point light on the camera, radius 240. DFU's
   `EnablePlayerTorch` uses range 6 Unity units, which is 240 Daggerfall units
   at `MeshReader.GlobalScale` (0.025).
@@ -246,11 +251,13 @@ Matching DFU:
 
 Ours, not DFU's:
 
-* **Exterior ambient** `(0.537, 0.549, 0.627)` is invented, and was tuned by
-  eye *before* the gamma fix, so it is now certainly too bright. DFU lerps
+* **Exterior ambient** `(0.255, 0.267, 0.358)` is invented. It is the older
+  eyeball-tuned `(0.537, 0.549, 0.627)` converted to linear (`c^2.2`) when
+  lighting moved to linear space, so it looks as it did before rather than
+  being washed out by the encode. DFU instead lerps
   `ExteriorNightAmbientLight (0.25)` to `ExteriorNoonAmbientLight (0.9)` by
-  daylight scale; ours is a fixed stand-in that cannot track time of day
-  because there is no time of day yet. Worth retuning once there is.
+  daylight scale; ours is fixed and cannot track time of day because there is
+  no time of day yet.
 * **Ambient is a floor, not a base.** `dir_light.frag` computes
   `max(ambient, diffuse * N.L)` where Unity adds ambient to everything, so ours
   has more contrast between lit and unlit surfaces.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -207,77 +207,79 @@ commitments:
 
 ## Lighting, measured against Daggerfall Unity
 
-Dungeon lighting is deliberately calibrated against DFU rather than eyeballed,
-so it is worth recording which numbers are theirs, which are ours, and what is
-still missing.
+Dungeon lighting is calibrated against DFU rather than eyeballed, so it is
+worth recording which numbers are theirs and which are ours.
 
-Matching DFU exactly:
+The single most important finding: **DFU renders in linear colour space**
+(`ProjectSettings.asset`, `m_ActiveColorSpace: 1`). It decodes sRGB textures to
+linear, lights in linear, and gamma-encodes on output. We were doing none of
+that -- multiplying gamma-encoded palette colours by linear light and writing
+the result straight out, which crushes midtones badly. Every DFU constant
+looked wrong here as a result, and the old `(1 - d^2/r^2)^2` falloff only
+looked acceptable because its excessive brightness cancelled the missing
+gamma. `object/sprite/terrain.frag` now decode albedo with `pow(c, 2.2)` into
+the RGBA16F G-buffer and `combiner.frag` encodes the lit result back; with
+that in place DFU's own numbers produce a sensible image.
 
-* **Dungeon ambient** `(0.12, 0.12, 0.12)` -- `PlayerAmbientLight.DungeonAmbientLight`.
+Matching DFU:
+
+* **Dungeon ambient** `(0.12, 0.12, 0.12)`, and **castle ambient** `0.58`
+  inside castle blocks -- `PlayerAmbientLight`. The castle flag comes from the
+  magnitude byte of a block's start marker (TEXTURE.199 record 10), the same
+  place `DaggerfallBillboard.cs` reads it; `World::updateCurrentBlock` tracks
+  which block the camera stands in so it changes as you walk.
 * **Light range** `radius * 3` -- `RDBLayout.AddLight`.
-* **Player torch** (`World::setSunLight`) -- a white point light on the camera,
-  radius 240. DFU's `EnablePlayerTorch` uses range 6 Unity units, which is 240
-  Daggerfall units at `MeshReader.GlobalScale` (0.025). Without it the RDB
-  lights alone leave dungeons far darker than DFU's, even at identical ambient;
-  adding it roughly doubles the brightness of the floor near the player and
-  leaves the far tunnel alone.
-* **Light flicker** (`FlickerCallback` in `render/pipeline.cpp`) -- DFU animates
-  dungeon and city lights but not interior ones (`Animate` is set on the Dungeon
-  and City light prefabs, clear on Interior). It varies *radius*, never
-  intensity: 14 ticks a second, each cycle picking a random target in
-  `[base - Variance, base]` and creeping toward it at `Speed` per tick, so the
-  light only ever dips below its base and drifts back. We use the same numbers
-  converted to Daggerfall units. Only RDB lights flicker; the torch is steady,
-  matching DFU, whose torch gutters only when the light item is nearly spent.
+* **Light intensity** 0.8 -- the `m_Intensity` on DFU's dungeon light prefab,
+  applied through `r_lightintensity`.
+* **Falloff** `1/(1 + 25*(d/r)^2)`, Unity's built-in point light shape,
+  rescaled to reach exactly zero at the radius so a light neither leaks past
+  its volume nor pops when it ends.
+* **Player torch** -- a white point light on the camera, radius 240. DFU's
+  `EnablePlayerTorch` uses range 6 Unity units, which is 240 Daggerfall units
+  at `MeshReader.GlobalScale` (0.025).
+* **Light flicker** (`FlickerCallback`) -- DFU animates dungeon and city lights
+  but not interior ones. It varies *radius*, never intensity: 14 ticks a
+  second, each cycle picking a random target in `[base - Variance, base]` and
+  creeping toward it, so a light only ever dips below base and drifts back.
+  Only RDB lights flicker; the torch is steady, matching DFU, whose torch
+  gutters only when the light item is nearly spent.
 
 Ours, not DFU's:
 
-* **Falloff.** We use `(1 - d^2/r^2)^2`; DFU gets Unity's built-in point light
-  falloff, which is far more concentrated near the source. At half the radius
-  ours is roughly 4x brighter. Ours reads as broad soft pools, DFU's as tight
-  bright cores.
-* **Light intensity.** DFU's dungeon light prefab sets `m_Intensity: 0.8`; our
-  point lights have no intensity at all and inherit the light pass default of
-  1.0.
-
-  These two are compensating errors, both pointing brighter. Change one without
-  the other and the result moves further from DFU, not closer -- they get fixed
-  together or not at all.
-* **Exterior ambient** `(0.537, 0.549, 0.627)` is invented. DFU lerps
+* **Exterior ambient** `(0.537, 0.549, 0.627)` is invented, and was tuned by
+  eye *before* the gamma fix, so it is now certainly too bright. DFU lerps
   `ExteriorNightAmbientLight (0.25)` to `ExteriorNoonAmbientLight (0.9)` by
-  daylight scale. Ours is a fixed overcast-midday stand-in that cannot track
-  time of day, because there is no time of day yet.
+  daylight scale; ours is a fixed stand-in that cannot track time of day
+  because there is no time of day yet. Worth retuning once there is.
 * **Ambient is a floor, not a base.** `dir_light.frag` computes
-  `max(ambient, diffuse * N.L)`, while Unity adds ambient to everything. Ours
+  `max(ambient, diffuse * N.L)` where Unity adds ambient to everything, so ours
   has more contrast between lit and unlit surfaces.
 
-Missing:
+Tuning knobs, as percentages because the cvar system has no float type. The
+`relight` console command re-applies all three without reloading:
 
-* **Castle and special-area ambient.** DFU switches to 0.58 -- nearly 5x the
-  dungeon value -- inside castle blocks and special areas, so Wayrest and the
-  main-story castles are far darker here than intended. `CastleBlock` is
-  derivable rather than curated (it comes from a billboard flat's
-  `resource.Magnitude != 0`, see `DaggerfallBillboard.cs`), but consuming it
-  needs per-block tracking of where the player is standing, which nothing else
-  needs yet.
+    r_ambientscale     100   scales whichever ambient is active
+    r_torchscale       100   the player torch
+    r_lightintensity    80   RDB point lights; DFU uses 0.8
+
+Still missing:
+
 * **Interior (building) ambient.** DFU has `InteriorAmbientLight` and a night
   variant; we only have sun-on and sun-off.
-* **User scaling.** DFU exposes `DungeonAmbientLightScale`,
-  `NightAmbientLightScale` and `PlayerTorchLightScale`. We have no cvars for
-  any of it.
+* **Special-area ambient.** DFU has `SpecialAreaLight` (also 0.58) for e.g. the
+  Daggerfall castle treasure room. It is tracked separately from the castle
+  flag and we do not read it.
+* **Night ambient scaling.** `NightAmbientLightScale` has no meaning without a
+  day/night cycle, so there is no cvar for it.
 
-One engine bug surfaced by this work and left unfixed: `engine.cpp`'s main loop
-calls `viewer->frame(timediff)`, passing the per-frame *delta* where OSG expects
-an absolute simulation time. `osg::FrameStamp::getSimulationTime()` is therefore
-pinned near 0.015 for the life of the process, and anything driven by it --
-osgAnimation, particle systems, `osg::Sequence` -- would silently never advance.
-`FlickerCallback` sidesteps it by using `getReferenceTime()`. Fixing the main
-loop is a small change with a wide blast radius and deserves to be its own.
-
-Also worth noting: `createPointLight` builds a *fullscreen* quad per light, so
-every light shades every pixel and the shader's `discard` only saves work after
-three G-buffer fetches. Fine for Privateer's Hold, but it scales with lights x
-screen pixels, and a dense block will hurt.
+Performance: each light is a *fullscreen* quad, so an off-screen light would
+otherwise cost a full screen of fragments (the shader's `discard` only saves
+work after three G-buffer fetches). The light pass runs under an ortho
+projection with `NO_CULLING`, so OSG cannot cull them for us;
+`LightCullCallback` tests each light's sphere against the *main* camera's
+frustum instead. At the Privateer's Hold spawn that skips 43 of 72 lights.
+DFU does the equivalent in `DungeonLightHandler`. Replacing the quads with real
+light volumes would go further, and has not been needed yet.
 
 ## Curated tables carried over from Daggerfall Unity
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -205,6 +205,80 @@ commitments:
 * **Packaging.** Getting a build into people's hands on all three platforms
   without them having to compile it.
 
+## Lighting, measured against Daggerfall Unity
+
+Dungeon lighting is deliberately calibrated against DFU rather than eyeballed,
+so it is worth recording which numbers are theirs, which are ours, and what is
+still missing.
+
+Matching DFU exactly:
+
+* **Dungeon ambient** `(0.12, 0.12, 0.12)` -- `PlayerAmbientLight.DungeonAmbientLight`.
+* **Light range** `radius * 3` -- `RDBLayout.AddLight`.
+* **Player torch** (`World::setSunLight`) -- a white point light on the camera,
+  radius 240. DFU's `EnablePlayerTorch` uses range 6 Unity units, which is 240
+  Daggerfall units at `MeshReader.GlobalScale` (0.025). Without it the RDB
+  lights alone leave dungeons far darker than DFU's, even at identical ambient;
+  adding it roughly doubles the brightness of the floor near the player and
+  leaves the far tunnel alone.
+* **Light flicker** (`FlickerCallback` in `render/pipeline.cpp`) -- DFU animates
+  dungeon and city lights but not interior ones (`Animate` is set on the Dungeon
+  and City light prefabs, clear on Interior). It varies *radius*, never
+  intensity: 14 ticks a second, each cycle picking a random target in
+  `[base - Variance, base]` and creeping toward it at `Speed` per tick, so the
+  light only ever dips below its base and drifts back. We use the same numbers
+  converted to Daggerfall units. Only RDB lights flicker; the torch is steady,
+  matching DFU, whose torch gutters only when the light item is nearly spent.
+
+Ours, not DFU's:
+
+* **Falloff.** We use `(1 - d^2/r^2)^2`; DFU gets Unity's built-in point light
+  falloff, which is far more concentrated near the source. At half the radius
+  ours is roughly 4x brighter. Ours reads as broad soft pools, DFU's as tight
+  bright cores.
+* **Light intensity.** DFU's dungeon light prefab sets `m_Intensity: 0.8`; our
+  point lights have no intensity at all and inherit the light pass default of
+  1.0.
+
+  These two are compensating errors, both pointing brighter. Change one without
+  the other and the result moves further from DFU, not closer -- they get fixed
+  together or not at all.
+* **Exterior ambient** `(0.537, 0.549, 0.627)` is invented. DFU lerps
+  `ExteriorNightAmbientLight (0.25)` to `ExteriorNoonAmbientLight (0.9)` by
+  daylight scale. Ours is a fixed overcast-midday stand-in that cannot track
+  time of day, because there is no time of day yet.
+* **Ambient is a floor, not a base.** `dir_light.frag` computes
+  `max(ambient, diffuse * N.L)`, while Unity adds ambient to everything. Ours
+  has more contrast between lit and unlit surfaces.
+
+Missing:
+
+* **Castle and special-area ambient.** DFU switches to 0.58 -- nearly 5x the
+  dungeon value -- inside castle blocks and special areas, so Wayrest and the
+  main-story castles are far darker here than intended. `CastleBlock` is
+  derivable rather than curated (it comes from a billboard flat's
+  `resource.Magnitude != 0`, see `DaggerfallBillboard.cs`), but consuming it
+  needs per-block tracking of where the player is standing, which nothing else
+  needs yet.
+* **Interior (building) ambient.** DFU has `InteriorAmbientLight` and a night
+  variant; we only have sun-on and sun-off.
+* **User scaling.** DFU exposes `DungeonAmbientLightScale`,
+  `NightAmbientLightScale` and `PlayerTorchLightScale`. We have no cvars for
+  any of it.
+
+One engine bug surfaced by this work and left unfixed: `engine.cpp`'s main loop
+calls `viewer->frame(timediff)`, passing the per-frame *delta* where OSG expects
+an absolute simulation time. `osg::FrameStamp::getSimulationTime()` is therefore
+pinned near 0.015 for the life of the process, and anything driven by it --
+osgAnimation, particle systems, `osg::Sequence` -- would silently never advance.
+`FlickerCallback` sidesteps it by using `getReferenceTime()`. Fixing the main
+loop is a small change with a wide blast radius and deserves to be its own.
+
+Also worth noting: `createPointLight` builds a *fullscreen* quad per light, so
+every light shades every pixel and the shader's `discard` only saves work after
+three G-buffer fetches. Fine for Privateer's Hold, but it scales with lights x
+screen pixels, and a dense block will hurt.
+
 ## Curated tables carried over from Daggerfall Unity
 
 Some facts about the data simply aren't *in* the data, so Daggerfall Unity

--- a/src/components/dfosg/texloader.cpp
+++ b/src/components/dfosg/texloader.cpp
@@ -76,7 +76,7 @@ class TexHeader {
 
 public:
     //static const uint16_t sUncompressed  = 0x0000;
-    static const uint16_t sRleCompressed = 0x0002;
+    //static const uint16_t sRleCompressed = 0x0002; // treated as uncompressed
     static const uint16_t sImageRle  = 0x0108;
     static const uint16_t sRecordRle = 0x1108;
     void load(std::istream &stream)
@@ -178,6 +178,97 @@ osg::Image *TexLoader::loadUncompressedSingle(size_t width, size_t height, const
     return image;
 }
 
+// Decode one frame of an ImageRle (0x0108) or RecordRle (0x1108) record. Both
+// share the same on-disk layout, decoded here as a per-row "special row header"
+// table -- so their handling is identical, only the compression code in the
+// TEXTURE record's header differs. Cross-checked against Daggerfall Unity's
+// TextureFile.cs ReadRle() (Assets/Scripts/API/TextureFile.cs).
+//
+// Layout, per frame:
+//   dataOffset + frame*height*4:
+//     height * { int16 rowOffset, uint16 rowEncoding }
+//   rowOffset is measured from the record start (entryOffset), NOT dataOffset.
+//   rowEncoding == 0x8000 marks the row as RLE:
+//     uint16 rowWidth
+//     stream of int16 probe values:
+//       probe < 0 -> repeat next byte |probe| times
+//       probe > 0 -> copy |probe| verbatim bytes
+//   anything else means the row is width raw palette bytes.
+void TexLoader::loadRleFrame(osg::Image *image, const Resource::Palette &palette,
+                             std::istream &stream, uint32_t entryOffset,
+                             uint32_t dataOffset, size_t width, size_t height,
+                             size_t frame)
+{
+    static constexpr uint16_t RleEncoded = 0x8000;
+    struct RowHeader { int16_t offset; uint16_t encoding; };
+
+    if(!stream.seekg(entryOffset + dataOffset + height * frame * 4))
+        throw std::runtime_error("Failed to seek to RLE row headers");
+
+    std::vector<RowHeader> headers(height);
+    for(RowHeader &h : headers)
+    {
+        h.offset   = static_cast<int16_t>(VFS::read_le16(stream));
+        h.encoding = VFS::read_le16(stream);
+    }
+
+    std::vector<uint8_t> row(width);
+    for(size_t y = 0; y < height; ++y)
+    {
+        if(!stream.seekg(entryOffset + headers[y].offset))
+            throw std::runtime_error("Failed to seek to RLE row data");
+
+        std::fill(row.begin(), row.end(), uint8_t{0});
+
+        if(headers[y].encoding == RleEncoded)
+        {
+            uint16_t rowWidth = VFS::read_le16(stream);
+            size_t x = 0;
+            while(x < rowWidth && stream)
+            {
+                int16_t probe = static_cast<int16_t>(VFS::read_le16(stream));
+                if(probe == 0)
+                    break; // ponytail: avoid the infinite loop DFU also has; no known files hit this
+                // Always consume the whole run from the stream; only the
+                // write into row[] is clamped, so an over-long row can't
+                // desync the following probes.
+                if(probe < 0)
+                {
+                    size_t count = static_cast<size_t>(-probe);
+                    uint8_t pixel = stream.get();
+                    for(size_t i = 0; i < count; ++i, ++x)
+                    {
+                        if(x < width) row[x] = pixel;
+                    }
+                }
+                else
+                {
+                    size_t count = static_cast<size_t>(probe);
+                    for(size_t i = 0; i < count; ++i, ++x)
+                    {
+                        uint8_t pixel = stream.get();
+                        if(x < width) row[x] = pixel;
+                    }
+                }
+            }
+        }
+        else
+        {
+            stream.read(reinterpret_cast<char*>(row.data()), width);
+        }
+
+        unsigned char *dst = image->data(0, y);
+        for(size_t x = 0; x < width; ++x)
+        {
+            const Resource::PaletteEntry &c = palette[row[x]];
+            *(dst++) = c.r;
+            *(dst++) = c.g;
+            *(dst++) = c.b;
+            *(dst++) = (row[x] == 0) ? 0 : 255;
+        }
+    }
+}
+
 void TexLoader::loadUncompressedMulti(osg::Image *image, const Resource::Palette &palette, std::istream &stream)
 {
     size_t width = VFS::read_le16(stream);
@@ -258,38 +349,53 @@ ImagePtrArray TexLoader::load(std::istream &stream, const TexEntryHeader &texent
         // Allocate a dummy image
         images.push_back(createDummyImage());
     }
-    else if(texhdr.getFrameCount() == 1)
-    {
-        osg::ref_ptr<osg::Image> image;
-
-        if(texhdr.getCompression() == texhdr.sRleCompressed)
-            std::cerr<< "Unhandled RleCompressed compression type"<< std::endl;
-        else if(texhdr.getCompression() == texhdr.sImageRle)
-            std::cerr<< "Unhandled ImageRle compression type"<< std::endl;
-        else if(texhdr.getCompression() == texhdr.sRecordRle)
-            std::cerr<< "Unhandled RecordRle compression type"<< std::endl;
-        else //if(texhdr.getCompression() == texhdr.sUncompressed)
-        {
-            if(!stream.seekg(texentry.getOffset() + texhdr.getDataOffset()))
-                throw std::runtime_error("Failed to seek to image offset");
-
-            image = loadUncompressedSingle(texhdr.getWidth(), texhdr.getHeight(), palette, stream);
-        }
-
-        if(!image)
-            image = createDummyImage();
-
-        images.push_back(image);
-    }
     else
     {
-        if(texhdr.getCompression() == texhdr.sRleCompressed)
-            std::cerr<< "Unhandled RleCompressed compression type"<< std::endl;
-        else if(texhdr.getCompression() == texhdr.sImageRle)
-            std::cerr<< "Unhandled ImageRle compression type"<< std::endl;
-        else if(texhdr.getCompression() == texhdr.sRecordRle)
-            std::cerr<< "Unhandled RecordRle compression type"<< std::endl;
-        else //if(texhdr.getCompression() == texhdr.sUncompressed)
+        // Compression 0x0002 (RleCompressed) despite the name is stored as
+        // uncompressed pixel data; DFU's TextureFile.cs treats it the same.
+        // 0x0108 (ImageRle) and 0x1108 (RecordRle) share the special-row-header
+        // decoder, only the record-header code differs.
+        const bool isRle = (texhdr.getCompression() == texhdr.sImageRle
+                         || texhdr.getCompression() == texhdr.sRecordRle);
+
+        if(texhdr.getFrameCount() == 1)
+        {
+            osg::ref_ptr<osg::Image> image(new osg::Image());
+            image->allocateImage(texhdr.getWidth(), texhdr.getHeight(), 1,
+                                 GL_RGBA, GL_UNSIGNED_BYTE);
+
+            if(isRle)
+            {
+                loadRleFrame(image, palette, stream, texentry.getOffset(),
+                             texhdr.getDataOffset(), texhdr.getWidth(),
+                             texhdr.getHeight(), 0);
+            }
+            else
+            {
+                if(!stream.seekg(texentry.getOffset() + texhdr.getDataOffset()))
+                    throw std::runtime_error("Failed to seek to image offset");
+                image = loadUncompressedSingle(texhdr.getWidth(), texhdr.getHeight(), palette, stream);
+            }
+
+            if(!image)
+                image = createDummyImage();
+
+            images.push_back(image);
+        }
+        else if(isRle)
+        {
+            for(uint32_t frame = 0; frame < texhdr.getFrameCount(); ++frame)
+            {
+                osg::ref_ptr<osg::Image> image(new osg::Image());
+                image->allocateImage(texhdr.getWidth(), texhdr.getHeight(), 1,
+                                     GL_RGBA, GL_UNSIGNED_BYTE);
+                loadRleFrame(image, palette, stream, texentry.getOffset(),
+                             texhdr.getDataOffset(), texhdr.getWidth(),
+                             texhdr.getHeight(), frame);
+                images.push_back(image);
+            }
+        }
+        else
         {
             if(!stream.seekg(texentry.getOffset() + texhdr.getDataOffset()))
                 throw std::runtime_error("Failed to seek to image offset");
@@ -305,14 +411,14 @@ ImagePtrArray TexLoader::load(std::istream &stream, const TexEntryHeader &texent
 
                 osg::Image *image = images.back();
                 image->allocateImage(texhdr.getWidth(), texhdr.getHeight(), 1,
-                                    GL_RGBA, GL_UNSIGNED_BYTE);
+                                     GL_RGBA, GL_UNSIGNED_BYTE);
 
                 loadUncompressedMulti(image, palette, stream);
             }
-        }
 
-        if(images.empty())
-            images.push_back(createDummyImage());
+            if(images.empty())
+                images.push_back(createDummyImage());
+        }
     }
 
     return images;

--- a/src/components/dfosg/texloader.hpp
+++ b/src/components/dfosg/texloader.hpp
@@ -41,6 +41,10 @@ class TexLoader {
                                        std::istream &stream);
     void loadUncompressedMulti(osg::Image *image, const Resource::Palette &palette,
                                std::istream &stream);
+    void loadRleFrame(osg::Image *image, const Resource::Palette &palette,
+                      std::istream &stream, uint32_t entryOffset,
+                      uint32_t dataOffset, size_t width, size_t height,
+                      size_t frame);
 
     ImagePtrArray load(std::istream &stream, const TexEntryHeader &texentry,
                        int16_t *xoffset, int16_t *yoffset, int16_t *xscale, int16_t *yscale,

--- a/src/components/mygui_osg/texture.cpp
+++ b/src/components/mygui_osg/texture.cpp
@@ -102,6 +102,12 @@ void Texture::loadFromFile(const std::string &fname)
             format = MyGUI::PixelFormat::L8A8;
             numelems = 2;
             break;
+        // MyGUI has no BGR pixel format, so BGR(A) images are reported as
+        // R8G8B8(A8) while the bytes stay BGR. That is fine for drawing -- GL
+        // swizzles from the image's own format -- but it does mean lock() hands
+        // back bytes in a different order than getFormat() advertises. Nothing
+        // locks a file-loaded texture (MyGUI only locks ones it createManual'd),
+        // and converting here would throw away the BGR path macOS wants.
         case GL_RGB:
         case GL_BGR:
             format = MyGUI::PixelFormat::R8G8B8;

--- a/src/components/resource/meshmanager.cpp
+++ b/src/components/resource/meshmanager.cpp
@@ -1,5 +1,8 @@
 
 #include <cstdint>
+#include <cassert>
+#include <algorithm>
+#include <iterator>
 #include "meshmanager.hpp"
 
 #include <osg/Node>
@@ -172,6 +175,89 @@ osg::ref_ptr<osg::Node> MeshManager::get(size_t idx)
     return geode;
 }
 
+namespace
+{
+
+// Flats that emit their own light rather than merely reflecting it: fires,
+// torches, braziers, glowing creatures. Daggerfall stores no flag for this, so
+// like Daggerfall Unity (TextureReader.cs emissiveTextures) it has to be a
+// list. Values are opendf texture ids, i.e. (archive << 7) | record.
+const uint16_t sEmissiveFlats[] = {
+  // archive 87 -- fireplace
+    11136,
+  // archive 101 -- lights (lit)
+    12930, 12931, 12933, 12934, 12935, 12936, 12937, 12938,
+    12939, 12940,
+  // archive 190 -- lights
+    24323, 24324, 24325,
+  // archive 200 -- lights
+    25607, 25608, 25609, 25610,
+  // archive 202 -- statue
+    25858,
+  // archive 208 -- brewing potion
+    26626,
+  // archive 210 -- dungeon light fixtures
+    26880, 26881, 26882, 26883, 26884, 26885, 26886, 26888,
+    26889, 26891, 26893, 26894, 26895, 26896, 26897, 26898,
+    26899, 26900, 26901, 26902, 26903, 26904, 26905, 26906,
+    26907, 26908, 26909,
+  // archive 253 -- dungeon misc flats
+    32394, 32401, 32402, 32403, 32406, 32425, 32432, 32433,
+    32434, 32435, 32436, 32459, 32461,
+  // archive 273 -- ghost
+    34944, 34945, 34946, 34947, 34948, 34949, 34950, 34951,
+    34952, 34953, 34954, 34955, 34956, 34957, 34958,
+  // archive 278 -- spectre
+    35584, 35585, 35586, 35587, 35588, 35589, 35590, 35591,
+    35592, 35593, 35594, 35595, 35596, 35597, 35598,
+  // archive 280 -- fire daedra
+    35840, 35841, 35842, 35843, 35844, 35845, 35846, 35847,
+    35848, 35849, 35850, 35851, 35852, 35853, 35854, 35855,
+    35856, 35857, 35858, 35859,
+  // archive 281 -- daedra lord
+    35968, 35969, 35970, 35971, 35972, 35973, 35974, 35975,
+    35976, 35977, 35978, 35979, 35980, 35981, 35982, 35983,
+    35984, 35985, 35986, 35987,
+  // archive 290 -- flame atronach
+    37120, 37121, 37122, 37123, 37124, 37125, 37126, 37127,
+    37128, 37129, 37130, 37131, 37132, 37133, 37134, 37135,
+    37136, 37137, 37138, 37139,
+  // archive 356
+    45568, 45570, 45571,
+  // archive 375
+    48000, 48001,
+  // archive 376
+    48128, 48129,
+  // archive 377
+    48256, 48257,
+  // archive 378
+    48384, 48385,
+  // archive 379
+    48512, 48513,
+  // archive 380
+    48643, 48645,
+  // archive 400
+    51202, 51203,
+  // archive 405
+    51842,
+  // archive 434
+    55555, 55557,
+  // archive 473
+    60544, 60545, 60546, 60547, 60548, 60549, 60550, 60551,
+    60552, 60553, 60554, 60555, 60556, 60557, 60558,
+};
+
+bool isEmissiveFlat(size_t texid)
+{
+    // The table is binary-searched, so a mis-ordered entry would silently stop
+    // matching rather than fail loudly.
+    assert(std::is_sorted(std::begin(sEmissiveFlats), std::end(sEmissiveFlats)));
+    return std::binary_search(std::begin(sEmissiveFlats), std::end(sEmissiveFlats),
+                              static_cast<uint16_t>(texid));
+}
+
+} // namespace
+
 osg::ref_ptr<osg::Node> MeshManager::loadFlat(size_t texid, bool centered, size_t *num_frames)
 {
     auto iter = mFlatCache.find(std::make_pair(texid, centered));
@@ -261,6 +347,12 @@ osg::ref_ptr<osg::Node> MeshManager::loadFlat(size_t texid, bool centered, size_
     ss->setAttributeAndModes(new osg::AlphaFunc(osg::AlphaFunc::LESS, 0.5f));
     ss->addUniform(new osg::Uniform("diffuseTex", 0));
     ss->setTextureAttribute(0, tex);
+    // sprite.frag writes this straight into the diffuse light buffer (the main
+    // pass's COLOR_BUFFER3), so a lit flat shows its own albedo at full
+    // brightness instead of waiting on a light to reach it. Texels the alpha
+    // test drops never get here, so the glow keeps the sprite's shape.
+    if(isEmissiveFlat(texid))
+        ss->addUniform(new osg::Uniform("illumination_color", osg::Vec4f(1.0f, 1.0f, 1.0f, 1.0f)));
 
     if(centered)
         bb->addDrawable(geometry);

--- a/src/opendf/engine.cpp
+++ b/src/opendf/engine.cpp
@@ -131,6 +131,34 @@ CVAR(CVarInt, vid_width, 1280, 0);
 CVAR(CVarInt, vid_height, 720, 0);
 CVAR(CVarBool, vid_fullscreen, false);
 
+// Screenshots. r_shotfile is the output prefix; OSG appends a serial number
+// and the extension. r_shotframe exists for non-interactive verification:
+// render that many frames, write one shot, and quit -- which is the only way
+// to see what the renderer actually produced without a live window to look at.
+CVAR(CVarString, r_shotfile, "opendf_shot");
+CVAR(CVarInt, r_shotframe, 0, 0);
+
+namespace
+{
+    osg::ref_ptr<osgViewer::ScreenCaptureHandler> sScreenCapture;
+    osgViewer::Viewer *sCaptureViewer = nullptr;
+}
+
+CCMD(screenshot)
+{
+    if(!sScreenCapture.valid() || !sCaptureViewer)
+    {
+        Log::get().stream(Log::Level_Error)<< "Screen capture is not available";
+        return;
+    }
+    if(!params.empty())
+        sScreenCapture->setCaptureOperation(
+            new osgViewer::ScreenCaptureHandler::WriteToFile(
+                params, "png", osgViewer::ScreenCaptureHandler::WriteToFile::SEQUENTIAL_NUMBER));
+    sScreenCapture->captureNextFrame(*sCaptureViewer);
+    Log::get().stream()<< "Screenshot queued";
+}
+
 CCMD(qqq)
 {
     SDL_Event evt{};
@@ -212,6 +240,16 @@ bool Engine::parseOptions(int argc, char *argv[])
         }
         else if(strcasecmp(argv[i], "-devparm") == 0)
             Log::get().setLevel(Log::Level_Debug);
+        else if(strcasecmp(argv[i], "-set") == 0)
+        {
+            // Applied after the config file loads, so it wins over it without
+            // having to edit (and permanently alter) the user's opendf.cfg.
+            if(i < argc-2)
+            {
+                mCVarOverrides.emplace_back(argv[i+1], argv[i+2]);
+                i += 2;
+            }
+        }
         else
         {
             std::stringstream str;
@@ -340,6 +378,12 @@ bool Engine::go(void)
         const Settings::ConfigSection &cvars = cf.getSection("CVars");
         for(const Settings::ConfigSection::value_type &cvar : cvars)
             CVar::setByName(cvar.first, cvar.second);
+
+        for(const auto &cvar : mCVarOverrides)
+        {
+            Log::get().stream()<< "  -set "<<cvar.first<<" = "<<cvar.second;
+            CVar::setByName(cvar.first, cvar.second);
+        }
     }
 
     Log::get().message("Initializing VFS...");
@@ -525,17 +569,8 @@ bool Engine::go(void)
             *r_fov, pipeline.getAspectRatio(), 10.0, 10000.0
         ));
 
-        // Add a light so we can see
-        osg::Vec3f lightDir(70.f, -100.f, 10.f);
-        lightDir.normalize();
-        osg::ref_ptr<osg::Node> light = pipeline.createDirectionalLight();
-        osg::StateSet *ss = light->getOrCreateStateSet();
-        ss->addUniform(new osg::Uniform("light_direction", lightDir));
-        ss->addUniform(new osg::Uniform("diffuse_color", osg::Vec4f(1.0f, 0.988f, 0.933f, 1.0f)));
-        ss->addUniform(new osg::Uniform("specular_color", osg::Vec4f(1.0f, 1.0f, 1.0f, 1.0f)));
-        pipeline.getLightingStateSet()->getUniform("ambient_color")->set(
-            osg::Vec4f(0.537f, 0.549f, 0.627f, 1.0f)
-        );
+        // The sun and the ambient level belong to the location, so World sets
+        // them up when it loads one (see World::setSunLight).
     }
 
     {
@@ -584,7 +619,16 @@ bool Engine::go(void)
     // Region: Daggerfall, Location: Privateer's Hold
     WorldIface::get().loadDungeonByExterior(17, 179);
 
+    sScreenCapture = new osgViewer::ScreenCaptureHandler(
+        new osgViewer::ScreenCaptureHandler::WriteToFile(
+            *r_shotfile, "png", osgViewer::ScreenCaptureHandler::WriteToFile::SEQUENTIAL_NUMBER), 1);
+    // F12; the default is 'c', which collides with movement keys.
+    sScreenCapture->setKeyEventTakeScreenShot(osgGA::GUIEventAdapter::KEY_F12);
+    viewer->addEventHandler(sScreenCapture.get());
+    sCaptureViewer = viewer.get();
+
     // And away we go!
+    int framenum = 0;
     Uint32 last_tick = SDL_GetTicks();
     while(!viewer->done() && pumpEvents())
     {
@@ -598,11 +642,28 @@ bool Engine::go(void)
         WorldIface::get().update(timediff);
 
         viewer->frame(timediff);
+
+        if(*r_shotframe > 0)
+        {
+            // One shot, then out. Capturing happens on the following frame, so
+            // give it one more before quitting.
+            if(++framenum == *r_shotframe)
+                sScreenCapture->captureNextFrame(*viewer);
+            else if(framenum > *r_shotframe)
+                break;
+        }
     }
     Log::get().message("Main loop shutting down...");
+    sScreenCapture = nullptr;
+    sCaptureViewer = nullptr;
     mSceneRoot->removeChildren(0, mSceneRoot->getNumChildren());
 
-    savecfg(std::string());
+    // -set is a transient override for one run; writing it back would quietly
+    // make a diagnostic flag permanent. Explicit `savecfg` still works.
+    if(mCVarOverrides.empty())
+        savecfg(std::string());
+    else
+        Log::get().message("Skipping config save (-set overrides active)");
 
     return true;
 }

--- a/src/opendf/engine.cpp
+++ b/src/opendf/engine.cpp
@@ -116,9 +116,17 @@ void makeDirRecurse(std::string path)
     }
     // mkdir -p semantics: a directory that already exists is success. Without
     // this the helper throws the first time it is pointed at an existing
-    // config dir.
+    // config dir. A *file* in the way is still a failure -- treating it as
+    // success would just move the error to the log or config write, where it
+    // is far harder to place.
     if(err != 0 && errno == EEXIST)
-        err = 0;
+    {
+        struct stat st{};
+        if(stat(path.c_str(), &st) == 0 && S_ISDIR(st.st_mode))
+            err = 0;
+        else
+            errno = ENOTDIR;
+    }
     if(err != 0)
     {
         std::stringstream sstr;

--- a/src/opendf/engine.cpp
+++ b/src/opendf/engine.cpp
@@ -44,6 +44,12 @@
 #include <direct.h>
 #define mkdir(x,y) _mkdir(x)
 #define S_IRWXU 0
+// MSVC's <sys/stat.h> has _S_IFMT/_S_IFDIR but not the POSIX S_ISDIR test.
+// Masking with _S_IFMT first is the POSIX definition; a plain & _S_IFDIR would
+// also report true for any other type sharing that bit.
+#ifndef S_ISDIR
+#define S_ISDIR(m) (((m) & _S_IFMT) == _S_IFDIR)
+#endif
 #endif
 
 

--- a/src/opendf/engine.cpp
+++ b/src/opendf/engine.cpp
@@ -114,6 +114,11 @@ void makeDirRecurse(std::string path)
             err = mkdir(path.c_str(), S_IRWXU);
         }
     }
+    // mkdir -p semantics: a directory that already exists is success. Without
+    // this the helper throws the first time it is pointed at an existing
+    // config dir.
+    if(err != 0 && errno == EEXIST)
+        err = 0;
     if(err != 0)
     {
         std::stringstream sstr;
@@ -236,7 +241,10 @@ bool Engine::parseOptions(int argc, char *argv[])
         else if(strcasecmp(argv[i], "-log") == 0)
         {
             if(i < argc-1)
+            {
                 Log::get().setLog(argv[++i]);
+                mLogPathSet = true;
+            }
         }
         else if(strcasecmp(argv[i], "-devparm") == 0)
             Log::get().setLevel(Log::Level_Debug);
@@ -347,6 +355,19 @@ bool Engine::pumpEvents()
 
 bool Engine::go(void)
 {
+    // Default the log next to settings.cfg instead of dropping opendf.log into
+    // whatever directory the engine happened to be started from. -log still
+    // wins, and is taken exactly as given.
+    if(!mLogPathSet)
+    {
+        std::string path = getUserConfigDir();
+        if(!path.empty())
+        {
+            path += "/opendf";
+            makeDirRecurse(path);
+            Log::get().setLog(path+"/opendf.log");
+        }
+    }
     Log::get().initialize();
 
     // Init everything except audio (we will use OpenAL for that)
@@ -481,6 +502,16 @@ bool Engine::go(void)
             sstr<< "SDL_CreateWindow Error: "<<SDL_GetError();
             throw std::runtime_error(sstr.str());
         }
+
+        // SDL switches text input on with the window, which hands every
+        // keystroke to the platform input method -- on macOS that engages the
+        // Input Method Kit and is where the IMKCFRunLoopWakeUpReliable chatter
+        // comes from. We only want text input while the console is open, and
+        // with a non-Latin IME active a live input method can swallow keys
+        // before the game sees them. Input::handleKeyboard already turns it
+        // on for the console; its `if(!SDL_IsTextInputActive())` guard only
+        // makes sense if it starts off, so start it off.
+        SDL_StopTextInput();
 
         SDLUtil::graphicswindow_SDL2();
         osg::ref_ptr<osg::GraphicsContext::Traits> traits = new osg::GraphicsContext::Traits;
@@ -641,7 +672,13 @@ bool Engine::go(void)
 
         WorldIface::get().update(timediff);
 
-        viewer->frame(timediff);
+        // No argument: OSG then uses its own reference time as the simulation
+        // time. Passing timediff here set the simulation time to the *delta*
+        // (~0.015) every frame, so osg::FrameStamp::getSimulationTime() never
+        // advanced and anything driven by it -- osgAnimation, particles,
+        // osg::Sequence -- silently stood still. timediff is still what the
+        // game systems above are stepped with; it was only ever wrong for OSG.
+        viewer->frame();
 
         if(*r_shotframe > 0)
         {

--- a/src/opendf/engine.hpp
+++ b/src/opendf/engine.hpp
@@ -35,6 +35,10 @@ class Engine {
     std::vector<const char*> mRootPaths;
     std::vector<std::pair<std::string,std::string>> mCVarOverrides;
 
+    // Set by -log. Without it the log goes next to settings.cfg in the user's
+    // config dir rather than into the working directory.
+    bool mLogPathSet = false;
+
     osg::ref_ptr<osg::Group> mSceneRoot;
 
     osg::ref_ptr<osg::Camera> mCamera;

--- a/src/opendf/engine.hpp
+++ b/src/opendf/engine.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <utility>
 
 #include <osg/ref_ptr>
 
@@ -32,6 +33,7 @@ class Engine {
     SDL_Window *mSDLWindow;
 
     std::vector<const char*> mRootPaths;
+    std::vector<std::pair<std::string,std::string>> mCVarOverrides;
 
     osg::ref_ptr<osg::Group> mSceneRoot;
 

--- a/src/opendf/input/input.cpp
+++ b/src/opendf/input/input.cpp
@@ -178,6 +178,13 @@ void Input::handleKeyboardEvent(const SDL_KeyboardEvent &evt)
         }
         else if(evt.keysym.sym == SDLK_F3)
             mViewer->getEventQueue()->keyPress(osgGA::GUIEventAdapter::KEY_F3);
+        else if(evt.keysym.sym == SDLK_F12)
+        {
+            // The ScreenCaptureHandler listens for KEY_F12 on the viewer's
+            // event queue, and SDL events never reach it on their own -- so
+            // without this the documented F12 screenshot key does nothing.
+            mViewer->getEventQueue()->keyPress(osgGA::GUIEventAdapter::KEY_F12);
+        }
 
     }
     else if(evt.state == SDL_RELEASED)

--- a/src/opendf/input/input.cpp
+++ b/src/opendf/input/input.cpp
@@ -180,15 +180,22 @@ void Input::handleKeyboardEvent(const SDL_KeyboardEvent &evt)
             mViewer->getEventQueue()->keyPress(osgGA::GUIEventAdapter::KEY_F3);
         else if(evt.keysym.sym == SDLK_F12)
         {
-            // The ScreenCaptureHandler listens for KEY_F12 on the viewer's
-            // event queue, and SDL events never reach it on their own -- so
-            // without this the documented F12 screenshot key does nothing.
+            // The ScreenCaptureHandler listens on the viewer's event queue,
+            // which SDL events never reach on their own. It acts on the
+            // *release*, not the press (verified against OSG 3.6.5: injecting
+            // only a keyPress captures nothing), so the release below is the
+            // half that actually takes the shot -- but send both so the
+            // handler sees a well-formed key event.
             mViewer->getEventQueue()->keyPress(osgGA::GUIEventAdapter::KEY_F12);
         }
 
     }
     else if(evt.state == SDL_RELEASED)
+    {
         GuiIface::get().injectKeyRelease(evt.keysym.sym);
+        if(evt.keysym.sym == SDLK_F12)
+            mViewer->getEventQueue()->keyRelease(osgGA::GUIEventAdapter::KEY_F12);
+    }
 }
 
 void Input::handleTextInputEvent(const SDL_TextInputEvent &evt)

--- a/src/opendf/render/pipeline.cpp
+++ b/src/opendf/render/pipeline.cpp
@@ -16,6 +16,9 @@
 
 #include <osgDB/ReadFile>
 
+#include <algorithm>
+#include <cstdlib>
+
 #include "renderer.hpp"
 
 
@@ -335,7 +338,75 @@ void RenderPipeline::removeDirectionalLight(osg::Node *node)
 // relying on the shader's radius test to discard fragments outside its volume.
 // Cost is one full-screen pass per light. If a dense block ever costs too much,
 // the upgrade is to draw a scissored light volume instead of a full quad.
-osg::Node* RenderPipeline::createPointLight(const osg::Vec3f &pos, float radius)
+namespace {
+
+// Daggerfall Unity animates its dungeon and city lights (but not interior
+// ones) by shrinking the light's radius and letting it drift back, never
+// growing past the base value -- see DaggerfallLight.AnimateLight(). It ticks
+// 14 times a second; each cycle picks a random target in
+// [base - Variance, base] and creeps toward it by Speed per tick.
+//
+// DFU's Variance and Speed are in Unity units, so they scale into Daggerfall
+// units by 1/MeshReader.GlobalScale (0.025). The ratio between them is what
+// sets the rhythm, and it survives the conversion unchanged.
+class FlickerCallback : public osg::UniformCallback
+{
+    static const constexpr float sVariance = 1.0f / 0.025f;  // 40: deepest dip
+    static const constexpr float sSpeed    = 0.4f / 0.025f;  // 16: units per tick
+    static const constexpr double sTickRate = 1.0 / 14.0;
+
+    const float mBase;
+    float mCurrent;
+    float mTarget;
+    bool mStepping = false;
+    double mNextTick = 0.0;
+
+public:
+    FlickerCallback(float base) : mBase(base), mCurrent(base), mTarget(base) { }
+
+    void operator()(osg::Uniform *uniform, osg::NodeVisitor *nv) override
+    {
+        const osg::FrameStamp *fs = nv->getFrameStamp();
+        if(!fs) return;
+
+        // Reference time, not simulation time: engine.cpp's main loop passes
+        // the per-frame delta to viewer->frame(), which OSG takes as an
+        // absolute simulation time, so getSimulationTime() is pinned near
+        // 0.015 forever. Reference time is the viewer's own wall clock and
+        // advances regardless.
+        // ponytail: works around that rather than fixing it -- correcting the
+        // main loop is a separate change with its own blast radius.
+        const double now = fs->getReferenceTime();
+        if(now < mNextTick) return;
+        mNextTick = now + sTickRate;
+
+        if(!mStepping)
+        {
+            // A dim light can have a base smaller than the variance, so clamp:
+            // a negative radius would make the falloff discard everywhere and
+            // switch the light off outright.
+            const float dip = sVariance * (float)std::rand() / (float)RAND_MAX;
+            mTarget = std::max(mBase - dip, 0.0f);
+            mStepping = true;
+        }
+        else if(mTarget <= mCurrent)
+        {
+            mCurrent -= sSpeed;
+            if(mCurrent <= mTarget) { mCurrent = mTarget; mStepping = false; }
+        }
+        else
+        {
+            mCurrent += sSpeed;
+            if(mCurrent >= mTarget) { mCurrent = mTarget; mStepping = false; }
+        }
+
+        uniform->set(mCurrent);
+    }
+};
+
+} // namespace
+
+osg::Node* RenderPipeline::createPointLight(const osg::Vec3f &pos, float radius, bool animate)
 {
     osg::ref_ptr<osg::Geode> light = createScreenQuad(osg::Vec2f(0.0f, 0.0f), 1.0f, 1.0f,
                                                       mTextureWidth, mTextureHeight);
@@ -343,7 +414,11 @@ osg::Node* RenderPipeline::createPointLight(const osg::Vec3f &pos, float radius)
     ss->setAttributeAndModes(new osg::Depth(osg::Depth::ALWAYS, 0.0, 1.0, false),
                              osg::StateAttribute::OFF);
     ss->addUniform(new osg::Uniform("light_position", pos));
-    ss->addUniform(new osg::Uniform("light_radius", radius));
+
+    osg::ref_ptr<osg::Uniform> radiusUniform = new osg::Uniform("light_radius", radius);
+    if(animate)
+        radiusUniform->setUpdateCallback(new FlickerCallback(radius));
+    ss->addUniform(radiusUniform.get());
 
     mLightPass->addChild(light.get());
     return light.release();

--- a/src/opendf/render/pipeline.cpp
+++ b/src/opendf/render/pipeline.cpp
@@ -323,7 +323,36 @@ osg::Node* RenderPipeline::createDirectionalLight()
 
 void RenderPipeline::removeDirectionalLight(osg::Node *node)
 {
-    mLightPass->removeChild(node);
+    // The pipeline is torn down before the world that owns the lights (see
+    // Engine::deinitialize), so by now the pass may already be gone -- in
+    // which case it took the light node with it.
+    if(mLightPass.valid())
+        mLightPass->removeChild(node);
+}
+
+
+// ponytail: a point light is a full-screen quad, same as the directional one,
+// relying on the shader's radius test to discard fragments outside its volume.
+// Cost is one full-screen pass per light. If a dense block ever costs too much,
+// the upgrade is to draw a scissored light volume instead of a full quad.
+osg::Node* RenderPipeline::createPointLight(const osg::Vec3f &pos, float radius)
+{
+    osg::ref_ptr<osg::Geode> light = createScreenQuad(osg::Vec2f(0.0f, 0.0f), 1.0f, 1.0f,
+                                                      mTextureWidth, mTextureHeight);
+    osg::StateSet *ss = setShaderProgram(light, "shaders/point_light.vert", "shaders/point_light.frag");
+    ss->setAttributeAndModes(new osg::Depth(osg::Depth::ALWAYS, 0.0, 1.0, false),
+                             osg::StateAttribute::OFF);
+    ss->addUniform(new osg::Uniform("light_position", pos));
+    ss->addUniform(new osg::Uniform("light_radius", radius));
+
+    mLightPass->addChild(light.get());
+    return light.release();
+}
+
+void RenderPipeline::removePointLight(osg::Node *node)
+{
+    if(mLightPass.valid())
+        mLightPass->removeChild(node);
 }
 
 

--- a/src/opendf/render/pipeline.cpp
+++ b/src/opendf/render/pipeline.cpp
@@ -13,6 +13,8 @@
 #include <osg/Program>
 #include <osg/Shader>
 #include <osg/Uniform>
+#include <osg/Polytope>
+#include <osg/NodeCallback>
 
 #include <osgDB/ReadFile>
 
@@ -369,14 +371,7 @@ public:
         const osg::FrameStamp *fs = nv->getFrameStamp();
         if(!fs) return;
 
-        // Reference time, not simulation time: engine.cpp's main loop passes
-        // the per-frame delta to viewer->frame(), which OSG takes as an
-        // absolute simulation time, so getSimulationTime() is pinned near
-        // 0.015 forever. Reference time is the viewer's own wall clock and
-        // advances regardless.
-        // ponytail: works around that rather than fixing it -- correcting the
-        // main loop is a separate change with its own blast radius.
-        const double now = fs->getReferenceTime();
+        const double now = fs->getSimulationTime();
         if(now < mNextTick) return;
         mNextTick = now + sTickRate;
 
@@ -404,6 +399,48 @@ public:
     }
 };
 
+// Each light is a fullscreen quad, so an off-screen light still costs a full
+// screen of fragments (the shader's discard only saves work after three
+// G-buffer fetches). The light pass runs under an ortho projection with
+// NO_CULLING, so OSG cannot cull these for us -- test the light's sphere of
+// influence against the *main* camera's frustum instead and skip the quad
+// entirely when it cannot affect anything visible. Daggerfall Unity does the
+// equivalent in DungeonLightHandler by disabling out-of-range lights.
+class LightCullCallback : public osg::NodeCallback
+{
+    const float mRadius;
+    osg::observer_ptr<osg::Camera> mMainPass;
+
+public:
+    LightCullCallback(float radius, osg::Camera *mainPass)
+      : mRadius(radius), mMainPass(mainPass) { }
+
+    void operator()(osg::Node *node, osg::NodeVisitor *nv) override
+    {
+        osg::ref_ptr<osg::Camera> main;
+        osg::StateSet *ss = node->getStateSet();
+        osg::Uniform *posUniform = ss ? ss->getUniform("light_position") : nullptr;
+        if(!mMainPass.lock(main) || !posUniform)
+        {
+            traverse(node, nv);
+            return;
+        }
+
+        // Read the position back rather than caching it, so a light that moves
+        // -- the player torch does, every frame -- is tested where it actually
+        // is. The radius is the base one, which flicker only ever dips below,
+        // so the sphere stays conservative.
+        osg::Vec3f pos;
+        posUniform->get(pos);
+
+        osg::Polytope frustum;
+        frustum.setToUnitFrustum();
+        frustum.transformProvidingInverse(main->getViewMatrix() * main->getProjectionMatrix());
+        if(frustum.contains(osg::BoundingSphere(pos, mRadius)))
+            traverse(node, nv);
+    }
+};
+
 } // namespace
 
 osg::Node* RenderPipeline::createPointLight(const osg::Vec3f &pos, float radius, bool animate)
@@ -419,6 +456,8 @@ osg::Node* RenderPipeline::createPointLight(const osg::Vec3f &pos, float radius,
     if(animate)
         radiusUniform->setUpdateCallback(new FlickerCallback(radius));
     ss->addUniform(radiusUniform.get());
+
+    light->setCullCallback(new LightCullCallback(radius, mMainPass.get()));
 
     mLightPass->addChild(light.get());
     return light.release();

--- a/src/opendf/render/pipeline.hpp
+++ b/src/opendf/render/pipeline.hpp
@@ -17,6 +17,7 @@ namespace osg
     class StateSet;
 
     class Vec2f;
+    class Vec3f;
 }
 
 namespace DF
@@ -78,6 +79,9 @@ public:
 
     osg::Node *createDirectionalLight();
     void removeDirectionalLight(osg::Node *node);
+
+    osg::Node *createPointLight(const osg::Vec3f &pos, float radius);
+    void removePointLight(osg::Node *node);
 
     void toggleDebugMapDisplay();
 

--- a/src/opendf/render/pipeline.hpp
+++ b/src/opendf/render/pipeline.hpp
@@ -80,7 +80,9 @@ public:
     osg::Node *createDirectionalLight();
     void removeDirectionalLight(osg::Node *node);
 
-    osg::Node *createPointLight(const osg::Vec3f &pos, float radius);
+    // animate: flicker the radius the way Daggerfall Unity animates its
+    // dungeon and city lights. Off for steady sources like the player torch.
+    osg::Node *createPointLight(const osg::Vec3f &pos, float radius, bool animate=false);
     void removePointLight(osg::Node *node);
 
     void toggleDebugMapDisplay();

--- a/src/opendf/world/dblocks.cpp
+++ b/src/opendf/world/dblocks.cpp
@@ -338,6 +338,9 @@ DBlockHeader::~DBlockHeader()
 
 void DBlockHeader::load(std::istream &stream, size_t blockid, float x, float z, size_t regnum, size_t locnum)
 {
+    mOriginX = x;
+    mOriginZ = z;
+
     mUnknown1 = VFS::read_le32(stream);
     mWidth = VFS::read_le32(stream);
     mHeight = VFS::read_le32(stream);
@@ -412,6 +415,27 @@ void DBlockHeader::load(std::istream &stream, size_t blockid, float x, float z, 
 
             offset = next;
         }
+    }
+
+    // Castle blocks. Daggerfall Unity reads this off the block's start marker
+    // (TEXTURE.199 record 10) -- DaggerfallBillboard.cs treats a non-zero
+    // magnitude as "castle block", and PlayerAmbientLight then uses a much
+    // brighter ambient inside one.
+    //
+    // Our FlatObject::load reads the same bytes DFU does, but pairs magnitude
+    // and sound index into one 16-bit mFactionId (DFU builds its
+    // FactionOrMobileId from exactly those two bytes, low byte first), so the
+    // magnitude is the low byte.
+    // Scanned directly rather than through getObjectByTexture(), which treats
+    // a missing flat as an error worth logging. Most blocks simply have no
+    // start marker -- only the ones that do can carry water level or castle
+    // status -- so its absence here is the normal case, not a fault.
+    for(const std::unique_ptr<FlatObject> &flat : mFlats)
+    {
+        if(flat->mTexture != Marker_StartID)
+            continue;
+        mCastleBlock = (flat->mFactionId & 0xff) != 0;
+        break;
     }
 }
 

--- a/src/opendf/world/dblocks.cpp
+++ b/src/opendf/world/dblocks.cpp
@@ -295,7 +295,7 @@ void LightObject::load(std::istream &stream, const osg::Vec3 &basepos)
     // Apply the same flip here so the light lands on the geometry it lights.
     osg::Vec3 pos = basepos + osg::Vec3(mXPos, mYPos, mZPos);
     mNode = RenderPipeline::get().createPointLight(
-        osg::Vec3(pos.x(), -pos.y(), -pos.z()), mRadius * 3.0f
+        osg::Vec3(pos.x(), -pos.y(), -pos.z()), mRadius * 3.0f, true
     );
 }
 

--- a/src/opendf/world/dblocks.cpp
+++ b/src/opendf/world/dblocks.cpp
@@ -15,6 +15,7 @@
 #include "components/resource/meshmanager.hpp"
 
 #include "render/renderer.hpp"
+#include "render/pipeline.hpp"
 #include "class/animated.hpp"
 #include "class/placeable.hpp"
 #include "class/activator.hpp"
@@ -114,6 +115,22 @@ struct FlatObject : public ObjectBase {
                       // those with associated actions.
 
     FlatObject(size_t id, int x, int y, int z) : ObjectBase(id, ObjectType_Flat, x, y, z) { }
+
+    void load(std::istream &stream, const osg::Vec3 &basepos);
+
+    virtual void print(std::ostream &stream) const final;
+};
+
+struct LightObject : public ObjectBase {
+    uint32_t mUnknown1;
+    uint32_t mUnknown2;
+    uint16_t mRadius;
+
+    // The light pass owns this node; we only keep it to remove it again.
+    osg::ref_ptr<osg::Node> mNode;
+
+    LightObject(size_t id, int x, int y, int z) : ObjectBase(id, ObjectType_Light, x, y, z) { }
+    virtual ~LightObject();
 
     void load(std::istream &stream, const osg::Vec3 &basepos);
 
@@ -259,6 +276,39 @@ void FlatObject::load(std::istream &stream, const osg::Vec3 &basepos)
     Placeable::get().setPoint(mId, pos);
 }
 
+LightObject::~LightObject()
+{
+    if(mNode.valid())
+        RenderPipeline::get().removePointLight(mNode.get());
+}
+
+void LightObject::load(std::istream &stream, const osg::Vec3 &basepos)
+{
+    mUnknown1 = VFS::read_le32(stream);
+    mUnknown2 = VFS::read_le32(stream);
+    mRadius = VFS::read_le16(stream);
+
+    // Daggerfall Unity uses radius*3 as the light's effective range (see
+    // RDBLayout.AddLight); the stored radius alone barely leaves the fixture.
+    // The light pass draws outside mSceneRoot, whose 180-degree X rotation
+    // (see Engine::initialize) every piece of world geometry goes through.
+    // Apply the same flip here so the light lands on the geometry it lights.
+    osg::Vec3 pos = basepos + osg::Vec3(mXPos, mYPos, mZPos);
+    mNode = RenderPipeline::get().createPointLight(
+        osg::Vec3(pos.x(), -pos.y(), -pos.z()), mRadius * 3.0f
+    );
+}
+
+void LightObject::print(std::ostream &stream) const
+{
+    DF::ObjectBase::print(stream);
+
+    stream<< "Unknown1: 0x"<<std::hex<<std::setw(8)<<mUnknown1<<std::dec<<std::setw(0)<<"\n";
+    stream<< "Unknown2: 0x"<<std::hex<<std::setw(8)<<mUnknown2<<std::dec<<std::setw(0)<<"\n";
+    stream<< "Radius: "<<mRadius<<"\n";
+}
+
+
 void FlatObject::print(std::ostream &stream) const
 {
     DF::ObjectBase::print(stream);
@@ -351,6 +401,14 @@ void DBlockHeader::load(std::istream &stream, size_t blockid, float x, float z, 
                 ).first->get();
                 flat->load(stream, basepos);
             }
+            else if(type == ObjectType_Light)
+            {
+                stream.seekg(objoffset);
+                LightObject *light = mLights.insert(blockid|offset,
+                    std::unique_ptr<LightObject>(new LightObject(blockid|offset, x, y, z))
+                ).first->get();
+                light->load(stream, basepos);
+            }
 
             offset = next;
         }
@@ -368,6 +426,11 @@ ObjectBase *DBlockHeader::getObject(size_t id)
     {
         auto iter = mFlats.find(id);
         if(iter != mFlats.end())
+            return iter->get();
+    }
+    {
+        auto iter = mLights.find(id);
+        if(iter != mLights.end())
             return iter->get();
     }
     return nullptr;
@@ -422,6 +485,13 @@ void DBlockHeader::print(std::ostream &stream, int objtype) const
     {
         stream<< "**** Object 0x"<<std::hex<<std::setw(8)<<*iditer<<std::setw(0)<<std::dec<<" ****\n";
         flat->print(stream);
+        ++iditer;
+    }
+    iditer = mLights.getIdList();
+    for(const std::unique_ptr<LightObject> &light : mLights)
+    {
+        stream<< "**** Object 0x"<<std::hex<<std::setw(8)<<*iditer<<std::setw(0)<<std::dec<<" ****\n";
+        light->print(stream);
         ++iditer;
     }
 }

--- a/src/opendf/world/dblocks.hpp
+++ b/src/opendf/world/dblocks.hpp
@@ -7,6 +7,8 @@
 #include <vector>
 #include <array>
 
+#include <osg/Vec3f>
+
 #include "misc/sparsearray.hpp"
 #include "referenceable.hpp"
 
@@ -64,6 +66,20 @@ struct DBlockHeader {
     Misc::SparseArray<std::unique_ptr<ModelObject>> mModels;
     Misc::SparseArray<std::unique_ptr<FlatObject>> mFlats;
     Misc::SparseArray<std::unique_ptr<LightObject>> mLights;
+
+    // Where this block sits in the dungeon grid, and whether it is a castle
+    // block. Daggerfall Unity brightens ambient a long way inside these
+    // (PlayerAmbientLight.CastleAmbientLight); the flag lives in the magnitude
+    // byte of the block's start marker, see load().
+    float mOriginX = 0.0f, mOriginZ = 0.0f;
+    bool mCastleBlock = false;
+
+    // True when P (in pre-flip object space) falls inside this block's cell.
+    bool contains(const osg::Vec3f &p) const
+    {
+        return p.x() >= mOriginX && p.x() < mOriginX+2048.0f
+            && p.z() >= mOriginZ && p.z() < mOriginZ+2048.0f;
+    }
 
     DBlockHeader();
     ~DBlockHeader();

--- a/src/opendf/world/dblocks.hpp
+++ b/src/opendf/world/dblocks.hpp
@@ -37,6 +37,7 @@ struct ObjectBase {
 };
 struct ModelObject;
 struct FlatObject;
+struct LightObject;
 
 enum {
     Marker_EnterID = 0x6388,
@@ -62,6 +63,7 @@ struct DBlockHeader {
 
     Misc::SparseArray<std::unique_ptr<ModelObject>> mModels;
     Misc::SparseArray<std::unique_ptr<FlatObject>> mFlats;
+    Misc::SparseArray<std::unique_ptr<LightObject>> mLights;
 
     DBlockHeader();
     ~DBlockHeader();

--- a/src/opendf/world/iface.hpp
+++ b/src/opendf/world/iface.hpp
@@ -41,6 +41,10 @@ public:
     virtual void dumpArea() const = 0;
     virtual void dumpBlocks() const = 0;
 
+    // Re-apply the lighting cvars (r_ambientscale, r_torchscale,
+    // r_lightintensity) to the live scene, for the `relight` command.
+    virtual void applyLightSettings() = 0;
+
     static WorldIface &get() { return sInstance; }
 };
 

--- a/src/opendf/world/mblocks.hpp
+++ b/src/opendf/world/mblocks.hpp
@@ -21,6 +21,11 @@ struct MObjectBase {
 
     void load(std::istream &stream);
 
+    // Virtual, so the destructor is too. Nothing deletes these through a
+    // base pointer today -- they live by value in the MBlock containers --
+    // but with print() virtual the vtable already exists, so this costs
+    // nothing and stops the day someone does from being undefined.
+    virtual ~MObjectBase() = default;
     virtual void print(std::ostream &stream) const;
 };
 struct MModel;

--- a/src/opendf/world/world.cpp
+++ b/src/opendf/world/world.cpp
@@ -488,6 +488,22 @@ void World::setSunLight(bool enable)
         enable ? osg::Vec4f(0.537f, 0.549f, 0.627f, 1.0f)
                : osg::Vec4f(0.120f, 0.120f, 0.120f, 1.0f)
     );
+
+    // Player torch, matching Daggerfall Unity's EnablePlayerTorch: a white
+    // point light on the player, intensity 1.0, range 6 Unity units -- which
+    // is 240 Daggerfall units at MeshReader.GlobalScale (0.025). Without it
+    // the RDB lights alone leave dungeons far darker than DFU's, even though
+    // our ambient constant matches theirs exactly.
+    // ponytail: always on underground. DFU gates it on a held light source
+    // and dims it as the item burns down; that needs an inventory we don't
+    // have yet, and a torch you can't lose beats a dungeon you can't see.
+    if(!mTorchLight.valid())
+        mTorchLight = pipeline.createPointLight(-mCameraPos, 240.0f);
+    osg::StateSet *tss = mTorchLight->getOrCreateStateSet();
+    osg::Vec4f torch = enable ? osg::Vec4f(0.0f, 0.0f, 0.0f, 1.0f)
+                              : osg::Vec4f(1.0f, 1.0f, 1.0f, 1.0f);
+    tss->getOrCreateUniform("diffuse_color", osg::Uniform::FLOAT_VEC4)->set(torch);
+    tss->getOrCreateUniform("specular_color", osg::Uniform::FLOAT_VEC4)->set(torch);
 }
 
 
@@ -677,6 +693,11 @@ void World::update(float timediff)
     ));
     matf.preMultTranslate(mCameraPos);
     mViewer->getCamera()->setViewMatrix(matf);
+
+    // mCameraPos is the negated eye position, flipped in y/z the same way
+    // LightObject::load flips an RDB light, so the torch sits at -mCameraPos.
+    if(mTorchLight.valid())
+        mTorchLight->getStateSet()->getUniform("light_position")->set(-mCameraPos);
 
     if(guimode == GuiIface::Mode_Game)
         mCurrentSelection = castCameraToViewportRay(0.5f, 0.5f, 1024.0f, false);

--- a/src/opendf/world/world.cpp
+++ b/src/opendf/world/world.cpp
@@ -236,6 +236,19 @@ CCMD(dwarp)
 
 CVAR(CVarBool, g_introspect, false);
 
+// Lighting tuning knobs. These are percentages because the cvar system has no
+// float type; Daggerfall Unity exposes the same first two as 0..1 floats
+// (DungeonAmbientLightScale, PlayerTorchLightScale) and hardcodes the third as
+// m_Intensity on its dungeon light prefab.
+CVAR(CVarInt, r_ambientscale,   100, 0, 400);   // scales whichever ambient is active
+CVAR(CVarInt, r_torchscale,     100, 0, 400);   // the player torch
+CVAR(CVarInt, r_lightintensity,  80, 0, 400);   // RDB point lights; DFU uses 0.8
+
+CCMD(relight)
+{
+    WorldIface::get().applyLightSettings();
+}
+
 
 World World::sWorld;
 WorldIface &WorldIface::sInstance = World::sWorld;
@@ -364,6 +377,12 @@ void World::deinitialize()
     mExterior.clear();
     mDungeon.clear();
     mSunLight = nullptr;
+    // The torch belongs to the pipeline's light pass, which deinitialize()
+    // drops. Holding a stale pointer would make the next setSunLight() skip
+    // creating a replacement and leave update() moving a detached node.
+    mTorchLight = nullptr;
+    mCurrentBlock = -1;
+    mInCastleBlock = false;
     Renderer::get().setObjectRoot(nullptr);
     mViewer = nullptr;
 }
@@ -476,18 +495,81 @@ void World::setSunLight(bool enable)
             new osg::Uniform("light_direction", lightDir));
     }
 
-    osg::StateSet *ss = mSunLight->getOrCreateStateSet();
-    osg::Vec4f sun = enable ? osg::Vec4f(1.0f, 0.988f, 0.933f, 1.0f)
-                            : osg::Vec4f(0.0f, 0.0f, 0.0f, 1.0f);
-    ss->getOrCreateUniform("diffuse_color", osg::Uniform::FLOAT_VEC4)->set(sun);
-    ss->getOrCreateUniform("specular_color", osg::Uniform::FLOAT_VEC4)->set(
-        enable ? osg::Vec4f(1.0f, 1.0f, 1.0f, 1.0f) : osg::Vec4f(0.0f, 0.0f, 0.0f, 1.0f));
+    mSunEnabled = enable;
+    applyLightSettings();
+}
 
-    // Dungeon ambient matches Daggerfall Unity's PlayerAmbientLight.
-    pipeline.getLightingStateSet()->getUniform("ambient_color")->set(
-        enable ? osg::Vec4f(0.537f, 0.549f, 0.627f, 1.0f)
-               : osg::Vec4f(0.120f, 0.120f, 0.120f, 1.0f)
-    );
+// Which dungeon block the camera is in. Only the castle flag is consumed so
+// far, and only on a change, so this costs a short scan on the frames where
+// you cross a block boundary and nothing on the rest.
+void World::updateCurrentBlock()
+{
+    if(mDungeon.empty())
+    {
+        if(mCurrentBlock != -1) { mCurrentBlock = -1; mInCastleBlock = false; }
+        return;
+    }
+
+    // Undo the negate-and-flip that built mCameraPos, to get back to the
+    // object space the blocks were placed in.
+    const osg::Vec3f p(-mCameraPos.x(), mCameraPos.y(), mCameraPos.z());
+
+    if(mCurrentBlock >= 0 && mCurrentBlock < (int)mDungeon.size()
+       && mDungeon[mCurrentBlock]->contains(p))
+        return;
+
+    for(size_t i = 0;i < mDungeon.size();++i)
+    {
+        if(!mDungeon[i]->contains(p))
+            continue;
+        mCurrentBlock = (int)i;
+        if(mInCastleBlock != mDungeon[i]->mCastleBlock)
+        {
+            mInCastleBlock = mDungeon[i]->mCastleBlock;
+            applyLightSettings();
+        }
+        return;
+    }
+}
+
+// Everything the lighting cvars touch, in one place so the `relight` console
+// command can re-apply them without reloading the world.
+void World::applyLightSettings()
+{
+    RenderPipeline &pipeline = RenderPipeline::get();
+    const bool enable = mSunEnabled;
+
+    const float ambientScale = *r_ambientscale / 100.0f;
+    const float torchScale   = *r_torchscale / 100.0f;
+    const float intensity    = *r_lightintensity / 100.0f;
+
+    if(mSunLight.valid())
+    {
+        osg::StateSet *ss = mSunLight->getOrCreateStateSet();
+        osg::Vec4f sun = enable ? osg::Vec4f(1.0f, 0.988f, 0.933f, 1.0f)
+                                : osg::Vec4f(0.0f, 0.0f, 0.0f, 1.0f);
+        ss->getOrCreateUniform("diffuse_color", osg::Uniform::FLOAT_VEC4)->set(sun);
+        ss->getOrCreateUniform("specular_color", osg::Uniform::FLOAT_VEC4)->set(
+            enable ? osg::Vec4f(1.0f, 1.0f, 1.0f, 1.0f) : osg::Vec4f(0.0f, 0.0f, 0.0f, 1.0f));
+    }
+
+    // Ambient matches Daggerfall Unity's PlayerAmbientLight: 0.12 underground,
+    // but 0.58 inside a castle block -- Daggerfall scales ambient up a long way
+    // in the main-story castles, and without this Wayrest is nearly five times
+    // too dark.
+    osg::Vec4f ambient = enable ? osg::Vec4f(0.537f, 0.549f, 0.627f, 1.0f)
+                    : (mInCastleBlock ? osg::Vec4f(0.580f, 0.580f, 0.580f, 1.0f)
+                                      : osg::Vec4f(0.120f, 0.120f, 0.120f, 1.0f));
+    ambient = osg::Vec4f(ambient.r()*ambientScale, ambient.g()*ambientScale,
+                         ambient.b()*ambientScale, 1.0f);
+    pipeline.getLightingStateSet()->getUniform("ambient_color")->set(ambient);
+
+    // RDB point lights set no colour of their own, so they inherit this one
+    // from the light pass -- which makes it the single place to scale them all.
+    // DFU's dungeon light prefab uses m_Intensity 0.8.
+    osg::StateSet *lss = pipeline.getLightingStateSet();
+    lss->getUniform("diffuse_color")->set(osg::Vec4f(intensity, intensity, intensity, 1.0f));
+    lss->getUniform("specular_color")->set(osg::Vec4f(intensity, intensity, intensity, 1.0f));
 
     // Player torch, matching Daggerfall Unity's EnablePlayerTorch: a white
     // point light on the player, intensity 1.0, range 6 Unity units -- which
@@ -501,7 +583,7 @@ void World::setSunLight(bool enable)
         mTorchLight = pipeline.createPointLight(-mCameraPos, 240.0f);
     osg::StateSet *tss = mTorchLight->getOrCreateStateSet();
     osg::Vec4f torch = enable ? osg::Vec4f(0.0f, 0.0f, 0.0f, 1.0f)
-                              : osg::Vec4f(1.0f, 1.0f, 1.0f, 1.0f);
+                              : osg::Vec4f(torchScale, torchScale, torchScale, 1.0f);
     tss->getOrCreateUniform("diffuse_color", osg::Uniform::FLOAT_VEC4)->set(torch);
     tss->getOrCreateUniform("specular_color", osg::Uniform::FLOAT_VEC4)->set(torch);
 }
@@ -596,6 +678,8 @@ void World::loadDungeonByExterior(int regnum, int extid)
         Log::get().stream()<< "Climate "<<(int)climate;
 
         Log::get().stream()<< "Entering "<<dinfo.mLocationName;
+        mCurrentBlock = -1;
+        mInCastleBlock = false;
         mDungeon.reserve(dinfo.mBlocks.size());
         for(const DungeonBlock &block : dinfo.mBlocks)
         {
@@ -698,6 +782,8 @@ void World::update(float timediff)
     // LightObject::load flips an RDB light, so the torch sits at -mCameraPos.
     if(mTorchLight.valid())
         mTorchLight->getStateSet()->getUniform("light_position")->set(-mCameraPos);
+
+    updateCurrentBlock();
 
     if(guimode == GuiIface::Mode_Game)
         mCurrentSelection = castCameraToViewportRay(0.5f, 0.5f, 1024.0f, false);

--- a/src/opendf/world/world.cpp
+++ b/src/opendf/world/world.cpp
@@ -557,7 +557,11 @@ void World::applyLightSettings()
     // but 0.58 inside a castle block -- Daggerfall scales ambient up a long way
     // in the main-story castles, and without this Wayrest is nearly five times
     // too dark.
-    osg::Vec4f ambient = enable ? osg::Vec4f(0.537f, 0.549f, 0.627f, 1.0f)
+    // Exterior ambient is the old eyeball-tuned value converted to linear
+    // (c^2.2), so it looks as it did before lighting moved to linear space
+    // rather than being washed out by the encode. Still ours, not DFU's, and
+    // still fixed until there is a time of day to interpolate over.
+    osg::Vec4f ambient = enable ? osg::Vec4f(0.255f, 0.267f, 0.358f, 1.0f)
                     : (mInCastleBlock ? osg::Vec4f(0.580f, 0.580f, 0.580f, 1.0f)
                                       : osg::Vec4f(0.120f, 0.120f, 0.120f, 1.0f));
     ambient = osg::Vec4f(ambient.r()*ambientScale, ambient.g()*ambientScale,
@@ -672,14 +676,19 @@ void World::loadDungeonByExterior(int regnum, int extid)
         mCurrentDungeon = &dinfo;
         mCurrentSelection = InvalidHandle;
 
+        // Cleared *before* setSunLight, which applies ambient using them: a
+        // stale castle flag from the dungeon we just left would otherwise pick
+        // the 0.58 ambient, and updateCurrentBlock() only re-applies on a
+        // change, so a non-castle start block would leave it stuck there.
+        mCurrentBlock = -1;
+        mInCastleBlock = false;
+
         setSunLight(false);
 
         uint8_t climate = getClimateValue(extloc.mX/256, extloc.mY/256);
         Log::get().stream()<< "Climate "<<(int)climate;
 
         Log::get().stream()<< "Entering "<<dinfo.mLocationName;
-        mCurrentBlock = -1;
-        mInCastleBlock = false;
         mDungeon.reserve(dinfo.mBlocks.size());
         for(const DungeonBlock &block : dinfo.mBlocks)
         {

--- a/src/opendf/world/world.cpp
+++ b/src/opendf/world/world.cpp
@@ -12,6 +12,8 @@
 
 #include <osgViewer/Viewer>
 #include <osg/Light>
+#include <osg/Uniform>
+#include <osg/StateSet>
 #include <osg/Quat>
 
 #include "components/vfs/manager.hpp"
@@ -361,6 +363,7 @@ void World::deinitialize()
 {
     mExterior.clear();
     mDungeon.clear();
+    mSunLight = nullptr;
     Renderer::get().setObjectRoot(nullptr);
     mViewer = nullptr;
 }
@@ -454,6 +457,40 @@ bool World::getExteriorByName(const std::string &name, size_t &regnum, size_t &m
     return false;
 }
 
+// The "global light" quad is always present: dir_light.frag computes
+// max(ambient, diffuse*N.L), so with a black diffuse it contributes just the
+// flat ambient term -- and it is the only thing that consumes ambient_color.
+// Outdoors that quad is a real sun over a bright sky ambient; underground the
+// sun goes black and the ambient drops to a dungeon level, leaving the RDB's
+// point lights to do the actual lighting.
+void World::setSunLight(bool enable)
+{
+    RenderPipeline &pipeline = RenderPipeline::get();
+
+    if(!mSunLight.valid())
+    {
+        osg::Vec3f lightDir(70.f, -100.f, 10.f);
+        lightDir.normalize();
+        mSunLight = pipeline.createDirectionalLight();
+        mSunLight->getOrCreateStateSet()->addUniform(
+            new osg::Uniform("light_direction", lightDir));
+    }
+
+    osg::StateSet *ss = mSunLight->getOrCreateStateSet();
+    osg::Vec4f sun = enable ? osg::Vec4f(1.0f, 0.988f, 0.933f, 1.0f)
+                            : osg::Vec4f(0.0f, 0.0f, 0.0f, 1.0f);
+    ss->getOrCreateUniform("diffuse_color", osg::Uniform::FLOAT_VEC4)->set(sun);
+    ss->getOrCreateUniform("specular_color", osg::Uniform::FLOAT_VEC4)->set(
+        enable ? osg::Vec4f(1.0f, 1.0f, 1.0f, 1.0f) : osg::Vec4f(0.0f, 0.0f, 0.0f, 1.0f));
+
+    // Dungeon ambient matches Daggerfall Unity's PlayerAmbientLight.
+    pipeline.getLightingStateSet()->getUniform("ambient_color")->set(
+        enable ? osg::Vec4f(0.537f, 0.549f, 0.627f, 1.0f)
+               : osg::Vec4f(0.120f, 0.120f, 0.120f, 1.0f)
+    );
+}
+
+
 void World::loadExterior(int regnum, int extid)
 {
     const MapRegion &region = mRegions.at(regnum);
@@ -465,6 +502,8 @@ void World::loadExterior(int regnum, int extid)
     mCurrentExterior = &extloc;
     mCurrentDungeon = nullptr;
     mCurrentSelection = InvalidHandle;
+
+    setSunLight(true);
 
     uint8_t climate = getClimateValue(extloc.mX/256, extloc.mY/256);
     Log::get().stream()<< "Climate "<<(int)climate;
@@ -534,6 +573,8 @@ void World::loadDungeonByExterior(int regnum, int extid)
         mCurrentExterior = &extloc;
         mCurrentDungeon = &dinfo;
         mCurrentSelection = InvalidHandle;
+
+        setSunLight(false);
 
         uint8_t climate = getClimateValue(extloc.mX/256, extloc.mY/256);
         Log::get().stream()<< "Climate "<<(int)climate;

--- a/src/opendf/world/world.hpp
+++ b/src/opendf/world/world.hpp
@@ -80,6 +80,11 @@ class World : public WorldIface {
     // point lights the RDB places -- so it's created and dropped per location.
     osg::ref_ptr<osg::Node> mSunLight;
 
+    // The player's torch: a point light that rides the camera underground.
+    // Daggerfall Unity carries one too, which is why its dungeons stay
+    // navigable at the same 0.12 ambient we use.
+    osg::ref_ptr<osg::Node> mTorchLight;
+
     bool mFirstStart;
 
     void setSunLight(bool enable);

--- a/src/opendf/world/world.hpp
+++ b/src/opendf/world/world.hpp
@@ -87,7 +87,17 @@ class World : public WorldIface {
 
     bool mFirstStart;
 
+    // Whether the last setSunLight() put us above ground; applyLightSettings()
+    // needs it to know which ambient to scale.
+    bool mSunEnabled = false;
+
+    // Which dungeon block the camera is standing in, and whether it is a
+    // castle block. Tracked so ambient can change as you walk into one.
+    int mCurrentBlock = -1;
+    bool mInCastleBlock = false;
+
     void setSunLight(bool enable);
+    void updateCurrentBlock();
 
     World();
     ~World();
@@ -120,6 +130,8 @@ public:
 
     virtual void dumpArea() const final;
     virtual void dumpBlocks() const final;
+
+    virtual void applyLightSettings() final;
 
     size_t castCameraToViewportRay(const float vpX, const float vpY, float maxDistance, bool ignoreFlats);
 };

--- a/src/opendf/world/world.hpp
+++ b/src/opendf/world/world.hpp
@@ -11,6 +11,7 @@
 #include <osg/Referenced>
 #include <osg/ref_ptr>
 #include <osg/Vec3>
+#include <osg/Node>
 
 #include "itembase.hpp"
 #include "pitems.hpp"
@@ -75,7 +76,13 @@ class World : public WorldIface {
     osg::Vec3f mCameraPos;
     osg::Vec3f mCameraRot;
 
+    // The outdoor sun. Dungeons don't get one -- their only light is the
+    // point lights the RDB places -- so it's created and dropped per location.
+    osg::ref_ptr<osg::Node> mSunLight;
+
     bool mFirstStart;
+
+    void setSunLight(bool enable);
 
     World();
     ~World();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic MyGUI setup during builds when a system installation is unavailable.
  * Added screenshot capture via F12, configurable filenames, frame-triggered captures, and `-set` launch-time overrides.
  * Added dynamic world lighting, torch and sun lighting, emissive surfaces, and flickering point lights.
  * Added support for loading compressed Daggerfall textures.

* **Bug Fixes**
  * Improved macOS/OpenGL shader compatibility and corrected color-space handling.
  * Prevented invalid lighting calculations and reduced unnecessary lighting work.
  * Improved support for BGR/BGRA textures.

* **Documentation**
  * Updated build instructions, lighting guidance, command-line options, and screenshot documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->